### PR TITLE
Fix/connect swagger

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -38,4 +38,3 @@ jobs:
         cd project
         python manage.py makemigrations
         python manage.py test
-        yes

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         sudo /etc/init.d/mysql start
         cd /usr/bin/
-        ./mysql -uroot -proot -e "create user 'admin'@'localhost' identified by 'waffleteam9';grant all privileges on test_toy_project.* to 'admin'@'localhost';"
+        ./mysql -uroot -proot -e "create user 'admin'@'localhost' identified by 'waffleteam9';grant all privileges on test_toy_project.* to 'admin'@'localhost';DROP DATABASE [IF EXISTS] test_toy_project;"
 
     - name: Run Tests
       run: |

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -38,3 +38,4 @@ jobs:
         cd project
         python manage.py makemigrations
         python manage.py test
+        yes

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         sudo /etc/init.d/mysql start
         cd /usr/bin/
-        ./mysql -uroot -proot -e "create user 'admin'@'localhost' identified by 'waffleteam9';grant all privileges on test_toy_project.* to 'admin'@'localhost';DROP DATABASE [IF EXISTS] test_toy_project;"
+        ./mysql -uroot -proot -e "create user 'admin'@'localhost' identified by 'waffleteam9';grant all privileges on test_toy_project.* to 'admin'@'localhost';DROP DATABASE test_toy_project;"
 
     - name: Run Tests
       run: |

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         sudo /etc/init.d/mysql start
         cd /usr/bin/
-        ./mysql -uroot -proot -e "create user 'admin'@'localhost' identified by 'waffleteam9';grant all privileges on test_toy_project.* to 'admin'@'localhost';DROP DATABASE test_toy_project;"
+        ./mysql -uroot -proot -e "create user 'admin'@'localhost' identified by 'waffleteam9';grant all privileges on test_toy_project.* to 'admin'@'localhost';"
 
     - name: Run Tests
       run: |

--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -2,6 +2,7 @@ from abc import ABC
 from django.contrib.auth import get_user_model, authenticate
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import update_last_login
+from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 from rest_framework_jwt.settings import api_settings
 from .models import Post, PostImage
@@ -60,5 +61,6 @@ class PostLikeSerializer(serializers.ModelSerializer):
         model = Post
         fields = ("likes", "likeusers")
 
+    @swagger_serializer_method(serializer_or_field=UserSerializer)
     def get_likeusers(self, post):
         return UserSerializer(post.likeusers, many=True).data

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -1,12 +1,14 @@
 from rest_framework import status, viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from typing import Type
+
 from .serializers import PostListSerializer, PostSerializer, PostLikeSerializer
 from .models import Post
 from user.models import User
 from datetime import datetime
 from django.shortcuts import get_object_or_404
-from drf_yasg.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema, no_body
 
 
 class PostViewSet(viewsets.GenericViewSet):
@@ -15,7 +17,7 @@ class PostViewSet(viewsets.GenericViewSet):
     queryset = Post.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
-    @swagger_auto_schema(operation_description="로그인된 유저의 friend들의 post를 최신순으로 가져오기")
+    @swagger_auto_schema(operation_description="로그인된 유저의 friend들의 post들을 최신순으로 가져오기")
     def list(self, request):
 
         # 쿼리셋을 효율적으로 쓰는법 http://raccoonyy.github.io/using-django-querysets-effectively-translate/
@@ -39,7 +41,7 @@ class LikeViewSet(viewsets.GenericViewSet):
     queryset = Post.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
-    @swagger_auto_schema(operation_description="좋아요하기")
+    @swagger_auto_schema(operation_description="좋아요하기", request_body=no_body)
     def update(self, request, pk=None):
         user = request.user
         post = get_object_or_404(self.queryset, pk=pk)
@@ -57,7 +59,9 @@ class LikeViewSet(viewsets.GenericViewSet):
         post.save()
         return Response(self.serializer_class(post).data, status=status.HTTP_200_OK)
 
-    @swagger_auto_schema(operation_description="좋아요 취소하기")
+    @swagger_auto_schema(
+        operation_description="좋아요 취소하기", responses={200: PostSerializer()}
+    )
     def destroy(self, request, pk=None):
         user = request.user
         post = get_object_or_404(self.queryset, pk=pk)
@@ -75,7 +79,10 @@ class LikeViewSet(viewsets.GenericViewSet):
         post.save()
         return Response(self.serializer_class(post).data, status=status.HTTP_200_OK)
 
-    @swagger_auto_schema(operation_description="해당 post의 좋아요 개수, 좋아요 한 유저 가져오기")
+    @swagger_auto_schema(
+        operation_description="해당 post의 좋아요 개수, 좋아요 한 유저 가져오기",
+        responses={200: PostLikeSerializer()},
+    )
     def retrieve(self, request, pk=None):
         post = get_object_or_404(self.queryset, pk=pk)
         return Response(PostLikeSerializer(post).data, status=status.HTTP_200_OK)

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -15,6 +15,7 @@ class PostViewSet(viewsets.GenericViewSet):
     queryset = Post.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
+    @swagger_auto_schema(operation_description="로그인된 유저의 friend들의 post를 최신순으로 가져오기")
     def list(self, request):
 
         # 쿼리셋을 효율적으로 쓰는법 http://raccoonyy.github.io/using-django-querysets-effectively-translate/
@@ -38,6 +39,7 @@ class LikeViewSet(viewsets.GenericViewSet):
     queryset = Post.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
+    @swagger_auto_schema(operation_description="좋아요하기")
     def update(self, request, pk=None):
         user = request.user
         post = get_object_or_404(self.queryset, pk=pk)
@@ -55,7 +57,8 @@ class LikeViewSet(viewsets.GenericViewSet):
         post.save()
         return Response(self.serializer_class(post).data, status=status.HTTP_200_OK)
 
-    def delete(self, request, pk=None):
+    @swagger_auto_schema(operation_description="좋아요 취소하기")
+    def destroy(self, request, pk=None):
         user = request.user
         post = get_object_or_404(self.queryset, pk=pk)
         if not post.likeusers.filter(id=user.id).exists():
@@ -72,6 +75,7 @@ class LikeViewSet(viewsets.GenericViewSet):
         post.save()
         return Response(self.serializer_class(post).data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(operation_description="해당 post의 좋아요 개수, 좋아요 한 유저 가져오기")
     def retrieve(self, request, pk=None):
         post = get_object_or_404(self.queryset, pk=pk)
         return Response(PostLikeSerializer(post).data, status=status.HTTP_200_OK)

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -31,8 +31,9 @@ class UserCreateSerializer(serializers.Serializer):
             "%Y-%m-%d",
         ],
         required=True,
+        help_text="Format: YYYY-MM-DD"
     )
-    gender = serializers.CharField(max_length=10, required=True)
+    gender = serializers.CharField(max_length=10, required=True, help_text="'Male' or 'Female'")
     password = serializers.CharField(max_length=128, required=True)
 
     # validate 정의

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -31,9 +31,11 @@ class UserCreateSerializer(serializers.Serializer):
             "%Y-%m-%d",
         ],
         required=True,
-        help_text="Format: YYYY-MM-DD"
+        help_text="Format: YYYY-MM-DD",
     )
-    gender = serializers.CharField(max_length=10, required=True, help_text="'Male' or 'Female'")
+    gender = serializers.CharField(
+        max_length=10, required=True, help_text="'Male' or 'Female'"
+    )
     password = serializers.CharField(max_length=128, required=True)
 
     # validate 정의

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -81,7 +81,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         # Django 기본 User 모델에 존재하는 필드 중 일부
-        fields = ()
+        fields = ("id", "email")
         extra_kwargs = {"password": {"write_only": True}}
 
     def validate(self, data):


### PR DESCRIPTION
스웨거에 자잘한 개선점들 몇 가지 추가했습니다!  
- user/serializers.py: 
`UserCreateSerializer`의 `birth`, `gender` 필드에 설명 추가했습니다.  
`newsfeed/serializers.py`의 `PostLikeSerializer`의 `author`필드가 비어있어서  일단 `UserSerializer`에 `id`, `email` 필드 명시하였습니다.   
혹시 문제가 된다면 이거를 위해서 따로 시리얼라이저를 하나 만들어야 될 것 같습니다  
  
- newsfeed/views.py:
`DELETE /like/{id} `가 스웨거에 뜨지 않았어서, 메소드 명을 `delete`에서 `destroy`로 변경하였고, 추가적으로 각 메소드에 대한 부가 설명을 덧붙였습니다  
Swagger에서 request 혹은 response 명세가 의도한 것과 다르게 나오는 것을 확인하여 해당 경우에는 형식을 명시해주었습니다  

- newsfeed/serializers.py:
drf-yasg가 `PostLikeSerializer`의 `get_likeusers()'까지 읽을 수 있도록 `@swagger_serializer_method`으로 태깅을 해줬습니다!
