### PR TITLE
Fix/swagger post create

### DIFF
--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -55,13 +55,16 @@ class PostViewSet(viewsets.GenericViewSet):
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
-                'content': openapi.Schema(type=openapi.TYPE_STRING, description='Post Content'),
-                'images': openapi.Schema(type=openapi.TYPE_ARRAY,
-                                         description='Array of Image URLs',
-                                         default=[],
-                                         items=openapi.TYPE_STRING,
-                                         ),
-            }
+                "content": openapi.Schema(
+                    type=openapi.TYPE_STRING, description="Post Content"
+                ),
+                "images": openapi.Schema(
+                    type=openapi.TYPE_ARRAY,
+                    description="Array of Image URLs",
+                    default=[],
+                    items=openapi.TYPE_STRING,
+                ),
+            },
         ),
     )
     def create(self, request):
@@ -106,8 +109,8 @@ class LikeViewSet(viewsets.GenericViewSet):
         if post.likeusers.filter(id=user.id).exists():
             return Response(status=status.HTTP_400_BAD_REQUEST, data="이미 좋아요 한 게시글입니다.")
         if (
-                not user.friends.filter(id=post.author.id).exists()
-                and post.author.id != user.id
+            not user.friends.filter(id=post.author.id).exists()
+            and post.author.id != user.id
         ):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."
@@ -128,8 +131,8 @@ class LikeViewSet(viewsets.GenericViewSet):
         if not post.likeusers.filter(id=user.id).exists():
             return Response(status=status.HTTP_400_BAD_REQUEST, data="좋아요하지 않은 게시글입니다.")
         if (
-                not user.friends.filter(id=post.author.id).exists()
-                and post.author.id != user.id
+            not user.friends.filter(id=post.author.id).exists()
+            and post.author.id != user.id
         ):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -82,9 +82,10 @@ class PostViewSet(viewsets.GenericViewSet):
             author_email = user.email
 
             for image in images:
-                PostImage.objects.create(
-                    post=post, image=image, author_email=author_email
-                )
+                if image:
+                    PostImage.objects.create(
+                        post=post, image=image, author_email=author_email
+                    )
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -25,7 +25,6 @@ jwt_header = openapi.Parameter(
 
 
 class PostViewSet(viewsets.GenericViewSet):
-
     serializer_class = PostSerializer
     queryset = Post.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
@@ -53,6 +52,17 @@ class PostViewSet(viewsets.GenericViewSet):
     @swagger_auto_schema(
         operation_description="Post 작성하기",
         manual_parameters=[jwt_header],
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'content': openapi.Schema(type=openapi.TYPE_STRING, description='Post Content'),
+                'images': openapi.Schema(type=openapi.TYPE_ARRAY,
+                                         description='Array of Image URLs',
+                                         default=[],
+                                         items=openapi.TYPE_STRING,
+                                         ),
+            }
+        ),
     )
     def create(self, request):
 
@@ -80,7 +90,6 @@ class PostViewSet(viewsets.GenericViewSet):
 
 
 class LikeViewSet(viewsets.GenericViewSet):
-
     serializer_class = PostSerializer
     queryset = Post.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
@@ -96,8 +105,8 @@ class LikeViewSet(viewsets.GenericViewSet):
         if post.likeusers.filter(id=user.id).exists():
             return Response(status=status.HTTP_400_BAD_REQUEST, data="이미 좋아요 한 게시글입니다.")
         if (
-            not user.friends.filter(id=post.author.id).exists()
-            and post.author.id != user.id
+                not user.friends.filter(id=post.author.id).exists()
+                and post.author.id != user.id
         ):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."
@@ -118,8 +127,8 @@ class LikeViewSet(viewsets.GenericViewSet):
         if not post.likeusers.filter(id=user.id).exists():
             return Response(status=status.HTTP_400_BAD_REQUEST, data="좋아요하지 않은 게시글입니다.")
         if (
-            not user.friends.filter(id=post.author.id).exists()
-            and post.author.id != user.id
+                not user.friends.filter(id=post.author.id).exists()
+                and post.author.id != user.id
         ):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."


### PR DESCRIPTION
# Create Post 수정 사항
## 1. `PostViewSet.create()`에 Swagger 데코레이터 달아주었습니다. 
`POST api/v1/newsfeed/`의 request body가 제대로 표시되지 않아 데코레이터로 직접 명시해주었습니다.
Request body에는 `content (str)`와 `images ([str])`, request header에는 JWT token을 넣어줄 수 있도록 다음과 같이 구현했습니다.
혹시 받아야 하는 게 더 있는지, 혹은 수정해야 할 부분이 있는지 검토 부탁드립니다!  

<img width="493" alt="스크린샷 2021-12-18 오후 5 26 51" src="https://user-images.githubusercontent.com/86173819/146634819-95ea7e7c-2f3f-4ff5-97ac-03a97d5cec56.png">  
  
  

##  2. Image가 blank 또는 null인 경우 걸러주기
`POST api/v1/newsfeed/`에서 `images` 필드에 `[""]`또는 `[null]`을 넣어주니 DB에 그대로 비어있는 레코드가 생성되는 걸 확인했습니다.
따라서 이와 같은 경우를 걸러주도록 살짝 수정했습니다.
