### PR TITLE
fix/swagger-newsfeed

### DIFF
--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -35,7 +35,7 @@ class PostListView(ListCreateAPIView):
         manual_parameters=[jwt_header],
         responses={200: PostListSerializer()},
     )
-    def list(self, request):
+    def get(self, request):
         user = request.user
         friends = user.friends.all()
         self.queryset = user.posts.all()
@@ -63,7 +63,7 @@ class PostListView(ListCreateAPIView):
         ),
         responses={201: PostSerializer()}
     )
-    def create(self, request):
+    def post(self, request):
 
         user = request.user
         images = request.data.get("images", None)

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -61,7 +61,7 @@ class PostListView(ListCreateAPIView):
                 ),
             },
         ),
-        responses={201: PostSerializer()}
+        responses={201: PostSerializer()},
     )
     def post(self, request):
 


### PR DESCRIPTION
1. **문제 내용**
Swagger에 newsfeed API 내용이 설정값대로 뜨지 않고 있었습니다 ㅠ

2. **문제 원인**    
https://github.com/wafflestudio19-5/team9-server/pull/31/ 에서 newsfeed의 implementation이 `ViewSet`에서 `APIView`로 바뀌었지만,  
이에 맞게 메소드명이 업데이트 되지 않아 `drf-yasg`가 해당 데코레이터를 읽지 못하고 있었습니다.  
  
    


3. **수정 사항**     
`list()`, `create()`을 각각 `get()`, `post()`으로 수정하였습니다.