### PR TITLE
posted_at 형식 맞추기

### DIFF
--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -76,6 +76,23 @@ class PostSerializer(serializers.ModelSerializer):
         return Comment.objects.filter(post=post).count()
 
 
+def format_time(time):
+    now = datetime.now()
+    time_elapsed = now - time
+    if time_elapsed < timedelta(minutes=1):
+        return "방금"
+    elif time_elapsed < timedelta(hours=1):
+        return f"{int(time_elapsed.seconds / 60)}분"
+    elif time_elapsed < timedelta(days=1):
+        return f"{int(time_elapsed.seconds / (60 * 60))}시간"
+    elif time_elapsed < timedelta(days=7):
+        return f"{time_elapsed.days}일"
+    elif time.year == now.year:
+        return f"{time.month}월 {time.day}일"
+    else:
+        return f"{time.year}년 {time.month}월 {time.day}일"
+
+
 class PostListSerializer(serializers.ModelSerializer):
 
     posted_at = serializers.SerializerMethodField()
@@ -97,11 +114,7 @@ class PostListSerializer(serializers.ModelSerializer):
         )
 
     def get_posted_at(self, post):
-
-        created_at = post.created
-        now = datetime.now()
-        duration = str(now - created_at).split(".")[0]
-        return duration
+        return format_time(post.created)
 
     @swagger_serializer_method(serializer_or_field=PostSerializer)
     def get_subposts(self, post):
@@ -217,10 +230,7 @@ class CommentListSerializer(serializers.ModelSerializer):
         return UserSerializer(comment.author).data
 
     def get_posted_at(self, comment):
-        created_at = comment.created
-        now = datetime.now()
-        duration = str(now - created_at).split(".")[0]
-        return duration
+        return format_time(comment.created)
 
     def get_children_count(self, comment):
         return comment.children.count()


### PR DESCRIPTION
실제 페이스북에 표시되는 것처럼 게시물 및 댓글 Serializer의 `posted_at` 필드를 수정했습니다!

게시 시점이...
- 1분이 안 됐으면 "방금"
- 1시간이 안 됐으면 "_분"
- 1일이 안 됐으면 "_시간"
- 1주가 안 됐으면 "_일"
- 조회 시점과 같은 년도면 "_월 _일"
- 조회 시점 이전의 년도면 "_년 _월 _일"