### PR TITLE
Refact/newsfeed naming

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -96,7 +96,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        "HOST": "database-careerly.cq3boo3w9eua.ap-northeast-2.rds.amazonaws.com",
+        "HOST": "localhost",
         "PORT": 3306,
         "NAME": "toy_project",  # database name 변경
         "USER": "admin",

--- a/project/newsfeed/pagination.py
+++ b/project/newsfeed/pagination.py
@@ -1,12 +1,6 @@
 from rest_framework.pagination import CursorPagination
 
 
-class CommentPagination(CursorPagination):
-    page_size = 20
-    ordering = "created"
-    cursor_query_param = "c"
-
-
 class NoticePagination(CursorPagination):
     page_size = 10
     ordering = "-created"

--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -27,7 +27,7 @@ class PostSerializer(serializers.ModelSerializer):
             "file",
             "created",
             "updated",
-            "like",
+            "likes",
             "comments",
         )
         extra_kwargs = {"content": {"help_text": "무슨 생각을 하고 계신가요?"}}

--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -12,7 +12,7 @@ from pytz import timezone
 class PostSerializer(serializers.ModelSerializer):
 
     subposts = serializers.SerializerMethodField()
-    comment_count = serializers.SerializerMethodField()
+    comments = serializers.SerializerMethodField()
 
     class Meta:
 
@@ -27,8 +27,8 @@ class PostSerializer(serializers.ModelSerializer):
             "file",
             "created",
             "updated",
-            "likes",
-            "comment_count",
+            "like",
+            "comments",
         )
         extra_kwargs = {"content": {"help_text": "무슨 생각을 하고 계신가요?"}}
 
@@ -59,7 +59,7 @@ class PostSerializer(serializers.ModelSerializer):
     def get_subposts(self, post):
         return PostSerializer(post.subposts, many=True).data
 
-    def get_comment_count(self, post):
+    def get_comments(self, post):
         return Comment.objects.filter(post=post).count()
 
 
@@ -103,7 +103,7 @@ class PostListSerializer(serializers.ModelSerializer):
     posted_at = serializers.SerializerMethodField()
     subposts = serializers.SerializerMethodField()
     author = serializers.SerializerMethodField()
-    comment_count = serializers.SerializerMethodField()
+    comments = serializers.SerializerMethodField()
 
     class Meta:
         model = Post
@@ -115,7 +115,7 @@ class PostListSerializer(serializers.ModelSerializer):
             "file",
             "likes",
             "posted_at",
-            "comment_count",
+            "comments",
         )
 
     def get_posted_at(self, post):
@@ -129,7 +129,7 @@ class PostListSerializer(serializers.ModelSerializer):
     def get_author(self, post):
         return UserSerializer(post.author).data
 
-    def get_comment_count(self, post):
+    def get_comments(self, post):
         return Comment.objects.filter(post=post).count()
 
 

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -694,11 +694,11 @@ class CommentTestCase(TestCase):
             author=cls.test_stranger, content="모르는 사람의 테스트 게시물입니다.", likes=30
         )
 
-        cls.depth_zero = CommentFactory.create(
-            author=cls.test_friend, post=cls.my_post, depth=0, content="depth 0"
-        )
         CommentFactory.create_batch(
             35, author=cls.test_friend, post=cls.my_post, depth=0
+        )
+        cls.depth_zero = CommentFactory.create(
+            author=cls.test_friend, post=cls.my_post, depth=0, content="depth 0"
         )
         cls.depth_one = CommentFactory.create(
             author=cls.test_friend,

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -7,7 +7,7 @@ from typing import Type
 from django.db.models import Q
 from django.db import transaction
 
-from .pagination import CommentPagination, NoticePagination
+from .pagination import NoticePagination
 from .serializers import (
     NoticeSerializer,
     NoticelistSerializer,
@@ -179,7 +179,6 @@ class PostLikeView(GenericAPIView):
 class CommentListView(ListCreateAPIView):
     serializer_class = CommentListSerializer
     queryset = Post.objects.all()
-    pagination_class = CommentPagination
     permission_classes = (permissions.IsAuthenticated,)
 
     @swagger_auto_schema(


### PR DESCRIPTION
1. newsfeed/serializers.py에서 `comment_count`필드명을 `comments`로 수정했습니다.
2. comment들을 paginate할 때 가장 상위 계층에서는 최근에 생성된 댓글을 먼저 표시하는 게 맞다고 생각하여 default pagination을 사용하도록 변경하였습니다.
3. 현재 Django Actions에서 테스트를 돌리는데 10분 남짓 걸리는 것 같은데, 시간 단축이 필요하다고 생각하여 test database를 저희 AWS의 RDS가 아닌 test machine의 localhost에 생성하도록 settings.py의 DB 정보를 수정하였습니다. 이제는 40초 내로 테스트가 완료되는 것을 확인할 수 있을 겁니다. 다만 저희 EC2만큼은 DB정보가 원래대로 유지되도록 신경써야 할 것 같습니다.