### PR TITLE
Fix/swagger

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -96,7 +96,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        "HOST": "database-careerly.cq3boo3w9eua.ap-northeast-2.rds.amazonaws.com",
+        "HOST": "localhost",
         "PORT": 3306,
         "NAME": "toy_project",  # database name 변경
         "USER": "admin",

--- a/project/newsfeed/urls.py
+++ b/project/newsfeed/urls.py
@@ -5,6 +5,7 @@ from .views import (
     CommentListView,
     CommentLikeView,
     NoticeView,
+    NoticeListView,
 )
 from rest_framework.routers import SimpleRouter
 from django.conf import settings
@@ -15,6 +16,6 @@ urlpatterns = [
     path("newsfeed/<int:post_id>/comment/", CommentListView.as_view()),
     path("newsfeed/<int:post_id>/like/", PostLikeView.as_view()),
     path("newsfeed/<int:post_id>/<int:comment_id>/like/", CommentLikeView.as_view()),
-    path("newsfeed/notices/", NoticeView.as_view()),
+    path("newsfeed/notices/", NoticeListView.as_view()),
     path("newsfeed/notices/<int:notice_id>/", NoticeView.as_view()),
 ]

--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -635,7 +635,7 @@ class UserProfileTestCase(APITestCase):
             data=data,
             HTTP_AUTHORIZATION=friend_token,
         )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         response = self.client.put(
             f"/api/v1/user/{self.test_user.id}/profile/",
             data=data,
@@ -740,7 +740,7 @@ class UserProfileTestCase(APITestCase):
             data=self.company_data,
             HTTP_AUTHORIZATION=friend_token,
         )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_put_company_profile_not_found(self):
         user_token = "JWT " + jwt_token_of(self.test_user)
@@ -771,7 +771,7 @@ class UserProfileTestCase(APITestCase):
             f"/api/v1/user/company/{self.test_user.company.last().id}/",
             HTTP_AUTHORIZATION=friend_token,
         )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_delete_company_profile_not_found(self):
         user_token = "JWT " + jwt_token_of(self.test_user)
@@ -846,7 +846,7 @@ class UserProfileTestCase(APITestCase):
             data=self.university_data,
             HTTP_AUTHORIZATION=friend_token,
         )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_put_university_profile_not_found(self):
         user_token = "JWT " + jwt_token_of(self.test_user)
@@ -877,7 +877,7 @@ class UserProfileTestCase(APITestCase):
             f"/api/v1/user/university/{self.test_user.university.last().id}/",
             HTTP_AUTHORIZATION=friend_token,
         )
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_delete_university_profile_not_found(self):
         user_token = "JWT " + jwt_token_of(self.test_user)

--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -979,6 +979,7 @@ class FriendTestCase(TestCase):
             HTTP_AUTHORIZATION=user_token,
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_accept_friend_request(self):
         user = self.test_user
         user_token = "JWT " + jwt_token_of(user)

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -310,7 +310,7 @@ class UserProfileView(RetrieveUpdateAPIView):
         user = get_object_or_404(User, pk=pk)
         if user != request.user:
             return Response(
-                status=status.HTTP_401_UNAUTHORIZED, data="다른 유저의 프로필을 고칠 수 없습니다."
+                status=status.HTTP_403_FORBIDDEN, data="다른 유저의 프로필을 고칠 수 없습니다."
             )
         profile_image = request.FILES.get("profile_image")
         if profile_image:
@@ -349,7 +349,7 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
         company = get_object_or_404(Company, pk=pk)
         if request.user != company.user:
             return Response(
-                status=status.HTTP_401_UNAUTHORIZED, data="다른 유저의 프로필을 고칠 수 없습니다."
+                status=status.HTTP_403_FORBIDDEN, data="다른 유저의 프로필을 고칠 수 없습니다."
             )
         return super().update(request, pk=pk, partial=True)
 
@@ -357,7 +357,7 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
         company = get_object_or_404(Company, pk=pk)
         if request.user != company.user:
             return Response(
-                status=status.HTTP_401_UNAUTHORIZED, data="다른 유저의 프로필을 고칠 수 없습니다."
+                status=status.HTTP_403_FORBIDDEN, data="다른 유저의 프로필을 고칠 수 없습니다."
             )
         return super().destroy(request, pk=pk)
 
@@ -390,7 +390,7 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
         university = get_object_or_404(University, pk=pk)
         if request.user != university.user:
             return Response(
-                status=status.HTTP_401_UNAUTHORIZED, data="다른 유저의 프로필을 고칠 수 없습니다."
+                status=status.HTTP_403_FORBIDDEN, data="다른 유저의 프로필을 고칠 수 없습니다."
             )
         return super().update(request, pk=pk, partial=True)
 
@@ -398,6 +398,6 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
         university = get_object_or_404(University, pk=pk)
         if request.user != university.user:
             return Response(
-                status=status.HTTP_401_UNAUTHORIZED, data="다른 유저의 프로필을 고칠 수 없습니다."
+                status=status.HTTP_403_FORBIDDEN, data="다른 유저의 프로필을 고칠 수 없습니다."
             )
         return super().destroy(request, pk=pk)

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -273,7 +273,7 @@ class UserNewsfeedView(ListAPIView):
     @swagger_auto_schema(
         operation_description="선택된 유저가 작성한 게시글을 가져오기",
         manual_parameters=[jwt_header],
-        responses={200: PostListSerializer(), 404: "유저를 찾을 수 없습니다."},
+        responses={200: PostListSerializer()},
     )
     def get(self, request, user_id=None):
         user = get_object_or_404(User, pk=user_id)
@@ -290,7 +290,7 @@ class UserFriendListView(ListAPIView):
     @swagger_auto_schema(
         operation_description="선택된 유저의 친구들을 가져오기",
         manual_parameters=[jwt_header],
-        responses={200: UserSerializer(), 404: "유저를 찾을 수 없습니다."},
+        responses={200: UserSerializer()},
     )
     def get(self, request, user_id=None):
         user = get_object_or_404(User, pk=user_id)
@@ -303,9 +303,19 @@ class UserProfileView(RetrieveUpdateAPIView):
     queryset = User.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
+    @swagger_auto_schema(
+        operation_description="유저의 프로필 정보 가져오기",
+        manual_parameters=[jwt_header],
+        responses={200: UserProfileSerializer()},
+    )
     def get(self, request, pk=None):
         return super().retrieve(request, pk=pk)
 
+    @swagger_auto_schema(
+        operation_description="프로필 정보 편집하기",
+        manual_parameters=[jwt_header],
+        responses={200: UserProfileSerializer()},
+    )
     def put(self, request, pk=None):
         user = get_object_or_404(User, pk=pk)
         if user != request.user:
@@ -320,12 +330,22 @@ class UserProfileView(RetrieveUpdateAPIView):
             user.cover_image.save(cover_image.name, cover_image, save=True)
         return super().update(request, pk=pk, partial=True)
 
+    # 부모의 patch 메서드를 drf-yasg가 읽지 않게 오버리이딩
+    @swagger_auto_schema(auto_schema=None)
+    def patch(self, request, *args, **kwargs):
+        return Response(status.HTTP_204_NO_CONTENT)
+
 
 class CompanyCreateView(CreateAPIView):
     serializer_class = CompanySerializer
     queryset = Company.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
+    @swagger_auto_schema(
+        operation_description="회사 정보 생성하기",
+        manual_parameters=[jwt_header],
+        responses={200: CompanySerializer()},
+    )
     def post(self, request):
         data = request.data.copy()
         data["user"] = request.user.id
@@ -342,9 +362,19 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
     queryset = Company.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
+    @swagger_auto_schema(
+        operation_description="회사 정보 가져오기",
+        manual_parameters=[jwt_header],
+        responses={200: CompanySerializer()},
+    )
     def get(self, request, pk=None):
         return super().retrieve(request, pk=pk)
 
+    @swagger_auto_schema(
+        operation_description="회사 정보 수정하기",
+        manual_parameters=[jwt_header],
+        responses={200: CompanySerializer()},
+    )
     def put(self, request, pk=None):
         company = get_object_or_404(Company, pk=pk)
         if request.user != company.user:
@@ -353,6 +383,10 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
             )
         return super().update(request, pk=pk, partial=True)
 
+    @swagger_auto_schema(
+        operation_description="회사 정보 삭제하기",
+        manual_parameters=[jwt_header],
+    )
     def delete(self, request, pk=None):
         company = get_object_or_404(Company, pk=pk)
         if request.user != company.user:
@@ -361,12 +395,22 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
             )
         return super().destroy(request, pk=pk)
 
+    # 부모의 patch 메서드를 drf-yasg가 읽지 않게 오버리이딩
+    @swagger_auto_schema(auto_schema=None)
+    def patch(self, request, *args, **kwargs):
+        return Response(status.HTTP_204_NO_CONTENT)
+
 
 class UniversityCreateView(CreateAPIView):
     serializer_class = UniversitySerializer
     queryset = University.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
+    @swagger_auto_schema(
+        operation_description="대학 정보 수정하기",
+        manual_parameters=[jwt_header],
+        responses={200: UniversitySerializer()},
+    )
     def post(self, request):
         data = request.data.copy()
         data["user"] = request.user.id
@@ -383,9 +427,19 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
     queryset = University.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
 
+    @swagger_auto_schema(
+        operation_description="대학 정보 가져오기",
+        manual_parameters=[jwt_header],
+        responses={200: UniversitySerializer()},
+    )
     def get(self, request, pk=None):
         return super().retrieve(request, pk=pk)
 
+    @swagger_auto_schema(
+        operation_description="대학 정보 수정하기",
+        manual_parameters=[jwt_header],
+        responses={200: UniversitySerializer()},
+    )
     def put(self, request, pk=None):
         university = get_object_or_404(University, pk=pk)
         if request.user != university.user:
@@ -394,6 +448,10 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
             )
         return super().update(request, pk=pk, partial=True)
 
+    @swagger_auto_schema(
+        operation_description="대학 정보 삭제하기",
+        manual_parameters=[jwt_header],
+    )
     def delete(self, request, pk=None):
         university = get_object_or_404(University, pk=pk)
         if request.user != university.user:
@@ -401,3 +459,8 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
                 status=status.HTTP_403_FORBIDDEN, data="다른 유저의 프로필을 고칠 수 없습니다."
             )
         return super().destroy(request, pk=pk)
+
+    # 부모의 patch 메서드를 drf-yasg가 읽지 않게 오버리이딩
+    @swagger_auto_schema(auto_schema=None)
+    def patch(self, request, *args, **kwargs):
+        return Response(status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
<h2>스웨거 관련 수정 사항</h2>  

- `user/views.py`, `newsfeed/views.py`에 스웨거 데코레이터를 달아주었습니다.  

- drf-yasg가 `newsfeed/notices/`에서 GET과 함께 의도되지 않은 DELETE도 표시하는 걸 확인했습니다. 여기서 DELETE를 없애기 위해 `newsfeed/views.py`에서 `NoticeView`를 `NoticeView`와 `NoticeListView`로 나누었습니다.  

- drf-yasg가 `/user/company/{company_id}`, `/user/university/{university_id}`에 의도되지 않은 PATCH 메소드를 표시하는 것을 확인했습니다. `UniversityView`, `CompanyView`의 부모 클래스인 `RetrieveUpdateDestroyView`의 `patch()`메소드를 drf-yasg가 읽어오는 것을 방지하기 위해 이를 각각 view에서 오버라이딩한 뒤 표시하지 말라는 데코레이터를 달아주었습니다.  

- `user/views.py`에서 접근 권한이 없는 경우에는 `403` status code을 띄우도록 수정했고, 해당 testcase도 이에 따라 고쳤습니다.  
