### PR TITLE
PUT like으로 좋아요를 toggle 가능하게 변경

### DIFF
--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -246,7 +246,7 @@ class NoticeTestCase(TestCase):
         self.assertNotEqual(data["results"][-1]["id"], notice_id)
 
         # 알림 취소
-        response = self.client.delete(
+        response = self.client.put(
             f"/api/v1/newsfeed/{self.test_post.id}/like/",
             content_type="application/json",
             HTTP_AUTHORIZATION=self.friends_token[0],
@@ -261,7 +261,7 @@ class NoticeTestCase(TestCase):
         self.assertEqual(data["results"][0]["count"], 8)
         self.assertEqual(len(data["results"][0]["senders"]), 9)
 
-        response = self.client.delete(
+        response = self.client.put(
             f"/api/v1/newsfeed/{self.test_post.id}/{self.test_comment.id}/like/",
             content_type="application/json",
             HTTP_AUTHORIZATION=self.friends_token[0],
@@ -568,7 +568,7 @@ class LikeTestCase(TestCase):
         data = response.json()
         self.assertEqual(data["likes"], 1)
 
-        response = self.client.delete(
+        response = self.client.put(
             "/api/v1/newsfeed/" + str(post.id) + "/like/",
             content_type="application/json",
             HTTP_AUTHORIZATION=user_token,
@@ -584,45 +584,6 @@ class LikeTestCase(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_duplicate_like_or_dislike(self):  # 2회 이상 좋아요 혹은 좋아요 취소
-        user = self.test_user
-        post = self.test_friend.posts.last()
-        user_token = "JWT " + jwt_token_of(user)
-        response = self.client.put(
-            "/api/v1/newsfeed/" + str(post.id) + "/like/",
-            content_type="application/json",
-            HTTP_AUTHORIZATION=user_token,
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        self.assertEqual(data["likes"], 1)
-        response = self.client.put(
-            "/api/v1/newsfeed/" + str(post.id) + "/like/",
-            content_type="application/json",
-            HTTP_AUTHORIZATION=user_token,
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        post.refresh_from_db()
-        self.assertEqual(post.likes, 1)
-
-        response = self.client.delete(
-            "/api/v1/newsfeed/" + str(post.id) + "/like/",
-            content_type="application/json",
-            HTTP_AUTHORIZATION=user_token,
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        self.assertEqual(data["likes"], 0)
-
-        response = self.client.delete(
-            "/api/v1/newsfeed/" + str(post.id) + "/like/",
-            content_type="application/json",
-            HTTP_AUTHORIZATION=user_token,
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        post.refresh_from_db()
-        self.assertEqual(post.likes, 0)
 
     def test_like_not_friend(self):  # 친구 아닌데 게시글 좋아요
         user = self.test_user
@@ -649,7 +610,7 @@ class LikeTestCase(TestCase):
         data = response.json()
         self.assertEqual(data["likes"], 1)
 
-        response = self.client.delete(
+        response = self.client.put(
             "/api/v1/newsfeed/" + str(post.id) + "/like/",
             content_type="application/json",
             HTTP_AUTHORIZATION=user_token,
@@ -922,7 +883,7 @@ class CommentTestCase(TestCase):
         self.assertEqual(data["likes"], 1)
         self.assertEqual(data["likeusers"][0]["id"], self.test_user.id)
 
-        response = self.client.delete(
+        response = self.client.put(
             f"/api/v1/newsfeed/{self.my_post.id}/{self.depth_zero.id}/like/",
             content_type="application/json",
             HTTP_AUTHORIZATION=user_token,

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -279,7 +279,9 @@ class CommentLikeView(GenericAPIView):
 
             post = comment.post
             if user.id != comment.author.id:
-                NoticeCreate(user=user, content="CommentLike", post=post, comment=comment)
+                NoticeCreate(
+                    user=user, content="CommentLike", post=post, comment=comment
+                )
 
         return Response(self.get_serializer(comment).data, status=status.HTTP_200_OK)
 

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -130,56 +130,41 @@ class PostLikeView(GenericAPIView):
     def put(self, request, post_id=None):
         user = request.user
         post = get_object_or_404(self.queryset, pk=post_id)
+        if (
+            not user.friends.filter(id=post.author.id).exists()
+            and post.author.id != user.id
+        ):
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."
+            )
+
+        # 이미 좋아요 한 게시물 -> 좋아요 취소, 관련 알림 삭제
         if post.likeusers.filter(id=user.id).exists():
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="이미 좋아요 한 게시글입니다.")
-        if (
-            not user.friends.filter(id=post.author.id).exists()
-            and post.author.id != user.id
-        ):
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."
-            )
-        post.likeusers.add(user)
-        post.likes = post.likes + 1
-        post.save()
+            post.likeusers.remove(user)
+            post.likes = post.likes - 1
+            post.save()
 
-        if user.id != post.author.id:
-            NoticeCreate(user=user, content="PostLike", post=post)
+            notice = Notice.objects.filter(post=post, comment=None)
+            if notice.exists():
+                notice = notice[0]
 
-        return Response(self.get_serializer(post).data, status=status.HTTP_200_OK)
+                if user in notice.senders.all():
+                    if notice.senders.count() > 1:
+                        notice.senders.remove(user)
+                        notice.count -= 1
+                        notice.save()
+                    else:
+                        notice.delete()
 
-    @swagger_auto_schema(
-        operation_description="게시물 좋아요 취소하기",
-        responses={200: PostSerializer()},
-        manual_parameters=[jwt_header],
-    )
-    def delete(self, request, post_id=None):
-        user = request.user
-        post = get_object_or_404(self.queryset, pk=post_id)
-        if not post.likeusers.filter(id=user.id).exists():
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="좋아요하지 않은 게시글입니다.")
-        if (
-            not user.friends.filter(id=post.author.id).exists()
-            and post.author.id != user.id
-        ):
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."
-            )
-        post.likeusers.remove(user)
-        post.likes = post.likes - 1
-        post.save()
+        # 좋아요 하지 않은 게시물 -> 좋아요 하기, 알림 생성
+        else:
+            post.likeusers.add(user)
+            post.likes = post.likes + 1
+            post.save()
 
-        notice = Notice.objects.filter(post=post, comment=None)
-        if notice.exists():
-            notice = notice[0]
+            if user.id != post.author.id:
+                NoticeCreate(user=user, content="PostLike", post=post)
 
-            if user in notice.senders.all():
-                if notice.senders.count() > 1:
-                    notice.senders.remove(user)
-                    notice.count -= 1
-                    notice.save()
-                else:
-                    notice.delete()
         return Response(self.get_serializer(post).data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
@@ -268,44 +253,34 @@ class CommentLikeView(GenericAPIView):
     def put(self, request, post_id=None, comment_id=None):
         user = request.user
         comment = get_object_or_404(self.queryset, pk=comment_id, post=post_id)
+
+        # 이미 좋아요 한 댓글 -> 좋아요 취소, 관련 알림 삭제
         if comment.likeusers.filter(id=user.id).exists():
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="이미 좋아요 한 댓글입니다.")
-        comment.likeusers.add(user)
-        comment.likes = comment.likes + 1
-        comment.save()
+            comment.likeusers.remove(user)
+            comment.likes = comment.likes - 1
+            comment.save()
 
-        post = comment.post
-        if user.id != comment.author.id:
-            NoticeCreate(user=user, content="CommentLike", post=post, comment=comment)
+            notice = Notice.objects.filter(comment=comment)
+            if notice.exists():
+                notice = notice[0]
+                if user in notice.senders.all():
+                    if notice.senders.count() > 1:
+                        notice.senders.remove(user)
+                        notice.count -= 1
+                        notice.save()
+                    else:
+                        notice.delete()
 
-        return Response(self.get_serializer(comment).data, status=status.HTTP_200_OK)
+        # 좋아요 하지 않은 댓글 -> 좋아요 하기, 알림 생성
+        else:
+            comment.likeusers.add(user)
+            comment.likes = comment.likes + 1
+            comment.save()
 
-    @swagger_auto_schema(
-        operation_description="comment 좋아요 취소하기",
-        responses={200: CommentSerializer()},
-        manual_parameters=[jwt_header],
-    )
-    def delete(self, request, post_id=None, comment_id=None):
-        user = request.user
-        comment = get_object_or_404(self.queryset, pk=comment_id, post=post_id)
+            post = comment.post
+            if user.id != comment.author.id:
+                NoticeCreate(user=user, content="CommentLike", post=post, comment=comment)
 
-        if not comment.likeusers.filter(id=user.id).exists():
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="좋아요하지 않은 댓글입니다.")
-
-        comment.likeusers.remove(user)
-        comment.likes = comment.likes - 1
-        comment.save()
-
-        notice = Notice.objects.filter(comment=comment)
-        if notice.exists():
-            notice = notice[0]
-            if user in notice.senders.all():
-                if notice.senders.count() > 1:
-                    notice.senders.remove(user)
-                    notice.count -= 1
-                    notice.save()
-                else:
-                    notice.delete()
         return Response(self.get_serializer(comment).data, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(


### PR DESCRIPTION
원래 PUT, DELETE으로 각각 좋아요, 좋아요 취소를 할 수 있었던 API를 PUT 하나로 합쳤습니다.
또, 이에 맞게 테스트케이스도 수정하였습니다.  

이제 `PUT /newsfeed/{post_id}/like/`, `PUT /newsfeed/{post_id}/{comment_id}/like/`으로 게시물과 댓글에 좋아요를 토글할 수 있습니다.  

좋아요를 한 건지 취소한 건지는 response에서 boolean필드인 is_liked으로 확인할 수 있습니다!