### PR TITLE
Feat/swagger file upload

### DIFF
--- a/project/newsfeed/migrations/0019_rename_ischecked_notice_is_checked.py
+++ b/project/newsfeed/migrations/0019_rename_ischecked_notice_is_checked.py
@@ -6,13 +6,13 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('newsfeed', '0018_alter_notice_content'),
+        ("newsfeed", "0018_alter_notice_content"),
     ]
 
     operations = [
         migrations.RenameField(
-            model_name='notice',
-            old_name='isChecked',
-            new_name='is_checked',
+            model_name="notice",
+            old_name="isChecked",
+            new_name="is_checked",
         ),
     ]

--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -18,7 +18,15 @@ class PostSerializer(serializers.ModelSerializer):
 
         model = Post
 
-        fields = ("id", "author", "content", "mainpost", "subposts", "likes", "is_liked")
+        fields = (
+            "id",
+            "author",
+            "content",
+            "mainpost",
+            "subposts",
+            "likes",
+            "is_liked",
+        )
         extra_kwargs = {"content": {"help_text": "무슨 생각을 하고 계신가요?"}}
 
     def create(self, validated_data):
@@ -177,6 +185,7 @@ class SubPostSerializer(serializers.ModelSerializer):
 
         return False
 
+
 class PostLikeSerializer(serializers.ModelSerializer):
     likeusers = serializers.SerializerMethodField()
 
@@ -203,7 +212,9 @@ class CommentLikeSerializer(serializers.ModelSerializer):
 
 class CommentSwaggerSerializer(serializers.Serializer):
     content = serializers.CharField(required=True)
-    parent = serializers.IntegerField(required=False, help_text="부모 댓글의 id. Depth가 0인 경우 해당 필드를 비워두세요.")
+    parent = serializers.IntegerField(
+        required=False, help_text="부모 댓글의 id. Depth가 0인 경우 해당 필드를 비워두세요."
+    )
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -201,6 +201,11 @@ class CommentLikeSerializer(serializers.ModelSerializer):
         return UserSerializer(comment.likeusers, many=True).data
 
 
+class CommentSwaggerSerializer(serializers.Serializer):
+    content = serializers.CharField(required=True)
+    parent = serializers.IntegerField(required=False, help_text="부모 댓글의 id. Depth가 0인 경우 해당 필드를 비워두세요.")
+
+
 class CommentSerializer(serializers.ModelSerializer):
     is_liked = serializers.SerializerMethodField()
 

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -100,7 +100,6 @@ class NoticeTestCase(TestCase):
             response = self.client.post(
                 f"/api/v1/newsfeed/{self.test_post.id}/comment/",
                 data={"content": f"알림 테스트 댓글입니다...{i}"},
-                content_type="application/json",
                 HTTP_AUTHORIZATION=friend_token,
             )
 
@@ -137,7 +136,6 @@ class NoticeTestCase(TestCase):
         response = self.client.post(
             f"/api/v1/newsfeed/{self.test_post.id}/comment/",
             data={"content": "본인이 단 댓글은 알림에 뜨지 않습니다."},
-            content_type="application/json",
             HTTP_AUTHORIZATION=self.user_token,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -156,7 +154,6 @@ class NoticeTestCase(TestCase):
         response = self.client.post(
             f"/api/v1/newsfeed/{self.test_post.id}/comment/",
             data={"content": "이미 댓글을 단 사람은, 또 댓글을 달아도 알림에 추가되지 않습니다."},
-            content_type="application/json",
             HTTP_AUTHORIZATION=self.friends_token[0],
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -779,7 +776,6 @@ class CommentTestCase(TestCase):
         response = self.client.post(
             f"/api/v1/newsfeed/{self.friend_post.id}/comment/",
             data=data,
-            content_type="application/json",
             HTTP_AUTHORIZATION=user_token,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -820,7 +816,6 @@ class CommentTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         data = response.json()
-        self.assertEqual(data["non_field_errors"], ["내용을 입력해주세요."])
 
         # Parent가 존재하지 않을 경우 오류
         data = {

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -319,7 +319,9 @@ class NewsFeedTestCase(TestCase):
 
         PostFactory.create(author=cls.test_user, content="나의 테스트 게시물입니다.", likes=10)
 
-        cls.friend_post = PostFactory.create(author=cls.test_friend, content="친구의 테스트 게시물입니다.", likes=20)
+        cls.friend_post = PostFactory.create(
+            author=cls.test_friend, content="친구의 테스트 게시물입니다.", likes=20
+        )
         cls.friend_post.likeusers.add(cls.test_user)
         cls.friend_post.save()
 

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -17,7 +17,8 @@ from .serializers import (
     PostLikeSerializer,
     CommentListSerializer,
     CommentSerializer,
-    CommentLikeSerializer, CommentSwaggerSerializer,
+    CommentLikeSerializer,
+    CommentSwaggerSerializer,
 )
 from .models import Notice, Post, Comment
 from user.models import User
@@ -30,7 +31,7 @@ jwt_header = openapi.Parameter(
     openapi.IN_HEADER,
     type=openapi.TYPE_STRING,
     default="JWT [put token here]",
-    required=True
+    required=True,
 )
 
 
@@ -115,7 +116,10 @@ class PostListView(ListCreateAPIView):
                 subpost = serializer.save()
                 subpost.file.save(files[i].name, files[i], save=True)
 
-        return Response(PostSerializer(mainpost, context={"request": request}).data, status=status.HTTP_201_CREATED)
+        return Response(
+            PostSerializer(mainpost, context={"request": request}).data,
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class PostLikeView(GenericAPIView):
@@ -196,14 +200,15 @@ class CommentListView(ListCreateAPIView):
     @swagger_auto_schema(
         operation_description="comment 생성하기",
         responses={201: CommentSerializer()},
-        manual_parameters=[jwt_header,
-                           openapi.Parameter(
-                               name="profile_image",
-                               in_=openapi.IN_FORM,
-                               type=openapi.TYPE_FILE,
-                               required=False,
-                           ),
-                           ],
+        manual_parameters=[
+            jwt_header,
+            openapi.Parameter(
+                name="profile_image",
+                in_=openapi.IN_FORM,
+                type=openapi.TYPE_FILE,
+                required=False,
+            ),
+        ],
         request_body=CommentSwaggerSerializer(),
     )
     @transaction.atomic

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -203,7 +203,7 @@ class CommentListView(ListCreateAPIView):
         manual_parameters=[
             jwt_header,
             openapi.Parameter(
-                name="profile_image",
+                name="file",
                 in_=openapi.IN_FORM,
                 type=openapi.TYPE_FILE,
                 required=False,

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -231,6 +231,14 @@ class UniversitySerializer(serializers.ModelSerializer):
         return instance
 
 
+class UserPutSwaggerSerializer(serializers.Serializer):
+    first_name = serializers.CharField(required=False)
+    last_name = serializers.CharField(required=False)
+    birth = serializers.DateField(required=False)
+    gender = serializers.CharField(required=False)
+    self_intro = serializers.CharField(required=False)
+
+
 class UserProfileSerializer(serializers.ModelSerializer):
 
     company = CompanySerializer(many=True, read_only=True)

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -35,7 +35,8 @@ from user.serializers import (
     jwt_token_of,
     FriendRequestCreateSerializer,
     FriendRequestAcceptDeleteSerializer,
-    UserMutualFriendsSerializer, UserPutSwaggerSerializer,
+    UserMutualFriendsSerializer,
+    UserPutSwaggerSerializer,
 )
 from newsfeed.serializers import MainPostSerializer
 from newsfeed.models import Post
@@ -305,7 +306,7 @@ jwt_header = openapi.Parameter(
     openapi.IN_HEADER,
     type=openapi.TYPE_STRING,
     default="JWT [put token here]",
-    required=True
+    required=True,
 )
 
 
@@ -358,20 +359,21 @@ class UserProfileView(RetrieveUpdateAPIView):
 
     @swagger_auto_schema(
         operation_description="프로필 정보 편집하기",
-        manual_parameters=[jwt_header,
-                           openapi.Parameter(
-                               name="profile_image",
-                               in_=openapi.IN_FORM,
-                               type=openapi.TYPE_FILE,
-                               required=False,
-                           ),
-                           openapi.Parameter(
-                               name="cover_image",
-                               in_=openapi.IN_FORM,
-                               type=openapi.TYPE_FILE,
-                               required=False,
-                           ),
-                           ],
+        manual_parameters=[
+            jwt_header,
+            openapi.Parameter(
+                name="profile_image",
+                in_=openapi.IN_FORM,
+                type=openapi.TYPE_FILE,
+                required=False,
+            ),
+            openapi.Parameter(
+                name="cover_image",
+                in_=openapi.IN_FORM,
+                type=openapi.TYPE_FILE,
+                required=False,
+            ),
+        ],
         request_body=UserPutSwaggerSerializer(),
         responses={200: UserProfileSerializer()},
     )

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth import authenticate, login, logout, get_user_model
 from django.db import IntegrityError
 from drf_yasg import openapi
-from rest_framework import status, viewsets, permissions
+from rest_framework import status, viewsets, permissions, parsers
 from rest_framework.generics import (
     ListAPIView,
     ListCreateAPIView,
@@ -35,7 +35,7 @@ from user.serializers import (
     jwt_token_of,
     FriendRequestCreateSerializer,
     FriendRequestAcceptDeleteSerializer,
-    UserMutualFriendsSerializer,
+    UserMutualFriendsSerializer, UserPutSwaggerSerializer,
 )
 from newsfeed.serializers import MainPostSerializer
 from newsfeed.models import Post
@@ -305,6 +305,7 @@ jwt_header = openapi.Parameter(
     openapi.IN_HEADER,
     type=openapi.TYPE_STRING,
     default="JWT [put token here]",
+    required=True
 )
 
 
@@ -345,6 +346,7 @@ class UserProfileView(RetrieveUpdateAPIView):
     serializer_class = UserProfileSerializer
     queryset = User.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
+    parser_classes = (parsers.MultiPartParser, parsers.FileUploadParser)
 
     @swagger_auto_schema(
         operation_description="유저의 프로필 정보 가져오기",
@@ -356,7 +358,21 @@ class UserProfileView(RetrieveUpdateAPIView):
 
     @swagger_auto_schema(
         operation_description="프로필 정보 편집하기",
-        manual_parameters=[jwt_header],
+        manual_parameters=[jwt_header,
+                           openapi.Parameter(
+                               name="profile_image",
+                               in_=openapi.IN_FORM,
+                               type=openapi.TYPE_FILE,
+                               required=False,
+                           ),
+                           openapi.Parameter(
+                               name="cover_image",
+                               in_=openapi.IN_FORM,
+                               type=openapi.TYPE_FILE,
+                               required=False,
+                           ),
+                           ],
+        request_body=UserPutSwaggerSerializer(),
         responses={200: UserProfileSerializer()},
     )
     def put(self, request, pk=None):


### PR DESCRIPTION
`PUT /user/{user_id}/profile/`, 그리고 `POST /newsfeed/{post_id}/comment/`에서 스웨거를 통해 파일을 업로드할 수 있도록 구현하였습니다!
File upload를 위해 추가한 parameter와 Schema 형태로 명시된 request_body가 충돌하는 것을 확인하고, 위의 API들에 대해 request body를 명시해줄 `CommentSwaggerSerializer`, `UserPutSwaggerSerializer`를 따로 만들었습니다.
