### PR TITLE
Refact/kakao login

### DIFF
--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -238,6 +238,7 @@ class UserPutSwaggerSerializer(serializers.Serializer):
     gender = serializers.CharField(required=False)
     self_intro = serializers.CharField(required=False)
 
+
 class UserLoginSwaggerSerializer(serializers.Serializer):
     success = serializers.BooleanField()
     user = UserSerializer()

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -238,6 +238,11 @@ class UserPutSwaggerSerializer(serializers.Serializer):
     gender = serializers.CharField(required=False)
     self_intro = serializers.CharField(required=False)
 
+class UserLoginSwaggerSerializer(serializers.Serializer):
+    success = serializers.BooleanField()
+    user = UserSerializer()
+    token = serializers.CharField()
+
 
 class UserProfileSerializer(serializers.ModelSerializer):
 

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -240,7 +240,6 @@ class UserPutSwaggerSerializer(serializers.Serializer):
 
 
 class UserLoginSwaggerSerializer(serializers.Serializer):
-    success = serializers.BooleanField()
     user = UserSerializer()
     token = serializers.CharField()
 

--- a/project/user/urls.py
+++ b/project/user/urls.py
@@ -5,8 +5,8 @@ from .views import (
     UserLoginView,
     UserSignUpView,
     UserLogoutView,
-    KakaoView,
-    KakaoCallbackView,
+    KakaoLoginView,
+    KakaoConnectView,
     UserNewsfeedView,
     UserFriendRequestView,
     UserFriendDeleteView,
@@ -25,10 +25,8 @@ urlpatterns = [
     path("signup/", UserSignUpView.as_view(), name="signup"),  # /api/v1/signup/
     path("login/", UserLoginView.as_view(), name="login"),  # /api/v1/login/
     path("logout/", UserLogoutView.as_view(), name="logout"),  # /api/v1/logout/
-    path("kakao/", KakaoView.as_view(), name="kakao_login"),  # /api/v1/kakao/
-    path(
-        "kakao/callback/", KakaoCallbackView.as_view(), name="kakao_callback"
-    ),  # /api/v1/kakao/callback/
+    path("kakao/login/", KakaoLoginView.as_view(), name="kakao_login"),  # /api/v1/kakao/login/
+    path("kakao/connect/", KakaoConnectView.as_view(), name="kakao_connect"),  # /api/v1/kakao/connect/
     path(
         "user/<int:user_id>/newsfeed/", UserNewsfeedView.as_view(), name="user_newsfeed"
     ),  # /api/v1/user/{user_id}/newsfeed/

--- a/project/user/urls.py
+++ b/project/user/urls.py
@@ -25,8 +25,12 @@ urlpatterns = [
     path("signup/", UserSignUpView.as_view(), name="signup"),  # /api/v1/signup/
     path("login/", UserLoginView.as_view(), name="login"),  # /api/v1/login/
     path("logout/", UserLogoutView.as_view(), name="logout"),  # /api/v1/logout/
-    path("kakao/login/", KakaoLoginView.as_view(), name="kakao_login"),  # /api/v1/kakao/login/
-    path("kakao/connect/", KakaoConnectView.as_view(), name="kakao_connect"),  # /api/v1/kakao/connect/
+    path(
+        "kakao/login/", KakaoLoginView.as_view(), name="kakao_login"
+    ),  # /api/v1/kakao/login/
+    path(
+        "kakao/connect/", KakaoConnectView.as_view(), name="kakao_connect"
+    ),  # /api/v1/kakao/connect/
     path(
         "user/<int:user_id>/newsfeed/", UserNewsfeedView.as_view(), name="user_newsfeed"
     ),  # /api/v1/user/{user_id}/newsfeed/

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -242,21 +242,6 @@ class UserSearchListView(ListAPIView):
         return super().list(request)
 
 
-KAKAO_APP_KEY = get_secret("KAKAO_APP_KEY")
-
-
-class KakaoView(APIView):
-    permission_classes = (permissions.AllowAny,)
-
-    def get(self, request):
-        app_key = KAKAO_APP_KEY
-        redirect_uri = "http://13.125.113.114/api/v1/kakao/callback"
-        kakao_auth_api = "https://kauth.kakao.com/oauth/authorize?response_type=code"
-        return redirect(
-            f"{kakao_auth_api}&client_id={app_key}&redirect_uri={redirect_uri}"
-        )
-
-
 class KakaoLoginView(APIView):
     permission_classes = (permissions.AllowAny,)
 

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -36,7 +36,8 @@ from user.serializers import (
     FriendRequestCreateSerializer,
     FriendRequestAcceptDeleteSerializer,
     UserMutualFriendsSerializer,
-    UserPutSwaggerSerializer, UserLoginSwaggerSerializer,
+    UserPutSwaggerSerializer,
+    UserLoginSwaggerSerializer,
 )
 from newsfeed.serializers import MainPostSerializer
 from newsfeed.models import Post
@@ -80,7 +81,9 @@ class UserSignUpView(APIView):
 class UserLoginView(APIView):
     permission_classes = (permissions.AllowAny,)
 
-    @swagger_auto_schema(request_body=UserLoginSerializer, responses={200: UserLoginSwaggerSerializer()})
+    @swagger_auto_schema(
+        request_body=UserLoginSerializer, responses={200: UserLoginSwaggerSerializer()}
+    )
     def post(self, request):
         serializer = UserLoginSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -265,12 +268,14 @@ class KakaoLoginView(APIView):
                 "access_token": openapi.Schema(type=openapi.TYPE_STRING),
             },
         ),
-        responses={200: UserLoginSwaggerSerializer()}
+        responses={200: UserLoginSwaggerSerializer()},
     )
     def post(self, request):
         access_token = request.data.get("access_token")
         if not access_token:
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="access_token이 전달되지 않았습니다.")
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data="access_token을 입력해주세요."
+            )
 
         # 유저 정보 받아오기
         user_info_response = requests.get(
@@ -281,12 +286,14 @@ class KakaoLoginView(APIView):
         kakao_id = user_info_response.json().get("id")
         if not kakao_id:
             return Response(
-                status=status.HTTP_400_BAD_REQUEST, data="access_token에 해당되는 카카오 계정이 없습니다."
+                status=status.HTTP_400_BAD_REQUEST, data="access_token이 유효하지 않습니다."
             )
 
         kakao = KakaoId.objects.filter(identifier=kakao_id)
         if not kakao.exists():
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="해당 카카오 계정과 연결된 계정이 없습니다.")
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data="해당 카카오 계정과 연결된 계정이 없습니다."
+            )
 
         user = kakao.first().user
         token = jwt_token_of(user)
@@ -313,7 +320,7 @@ class KakaoConnectView(APIView):
                 "access_token": openapi.Schema(type=openapi.TYPE_STRING),
             },
         ),
-        responses={201: "성공적으로 연결되었습니다."}
+        responses={201: "성공적으로 연결되었습니다."},
     )
     def post(self, request):
         if request.user.is_anonymous:
@@ -321,7 +328,9 @@ class KakaoConnectView(APIView):
 
         access_token = request.data.get("access_token")
         if not access_token:
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="access_token이 전달되지 않았습니다.")
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data="access_token을 입력해주세요."
+            )
 
         # 유저 정보 받아오기
         user_info_response = requests.get(
@@ -332,7 +341,7 @@ class KakaoConnectView(APIView):
         kakao_id = user_info_response.json().get("id")
         if not kakao_id:
             return Response(
-                status=status.HTTP_400_BAD_REQUEST, data="access_token에 해당되는 카카오 계정이 없습니다."
+                status=status.HTTP_400_BAD_REQUEST, data="access_token이 유효하지 않습니다."
             )
 
         if hasattr(request.user, "kakao"):

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -92,7 +92,6 @@ class UserLoginView(APIView):
 
         return Response(
             {
-                "success": True,
                 "user": UserSerializer(user).data,
                 "token": token,
             },
@@ -285,7 +284,6 @@ class KakaoLoginView(APIView):
 
         return Response(
             {
-                "success": True,
                 "user": UserSerializer(user).data,
                 "token": token,
             },


### PR DESCRIPTION
- 이전의 카카오 API를 삭제하고 `POST /kakao/login/`, `POST /kakao/connect/` 두 개의 API를 새로 만들었습니다. 둘 모두 request body에 data로 `access_token`을 받고, 각각 로그인, 그리고 계정 연동을 담당합니다.  

- 스웨거에서 로그인 메소드의 response를 올바르게 표시하기 위해 `UserLoginSwaggerSerializer`를 추가하였고, 이를 카카오 로그인과 일반 로그인의 스웨거 데코레이터에 달아주었습니다.

- 카카오 로그인 또는 일반 로그인 성공했을 때의 response에서 success 필드를 제거하였습니다.