### PR TITLE
Fix/comment order

### DIFF
--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -315,10 +315,7 @@ class CommentListSerializer(serializers.ModelSerializer):
         return comment.children.count()
 
     def get_children(self, comment):
-        children = comment.children.order_by("created")
-        # child comment 3개만 노출시키기
-        # if children.count() > 2:
-        #     children = children[children.count()-4:]
+        children = comment.children.order_by("-created")
         return CommentListSerializer(children, many=True, context=self.context).data
 
     def get_is_liked(self, comment):

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -698,6 +698,9 @@ class CommentTestCase(TestCase):
         cls.depth_zero = CommentFactory.create(
             author=cls.test_friend, post=cls.my_post, depth=0, content="depth 0"
         )
+        CommentFactory.create_batch(
+            5, author=cls.test_friend, post=cls.my_post, depth=1, parent=cls.depth_zero
+        )
         cls.depth_one = CommentFactory.create(
             author=cls.test_friend,
             post=cls.my_post,
@@ -707,8 +710,9 @@ class CommentTestCase(TestCase):
         )
         cls.depth_one.likeusers.add(cls.test_user)
         cls.depth_one.save()
+
         CommentFactory.create_batch(
-            5, author=cls.test_friend, post=cls.my_post, depth=1, parent=cls.depth_zero
+            5, author=cls.test_friend, post=cls.my_post, depth=2, parent=cls.depth_one
         )
         cls.depth_two = CommentFactory.create(
             author=cls.test_friend,
@@ -717,9 +721,7 @@ class CommentTestCase(TestCase):
             content="depth 2",
             parent=cls.depth_one,
         )
-        CommentFactory.create_batch(
-            5, author=cls.test_friend, post=cls.my_post, depth=2, parent=cls.depth_one
-        )
+
 
     def test_comment_list(self):
 

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -722,7 +722,6 @@ class CommentTestCase(TestCase):
             parent=cls.depth_one,
         )
 
-
     def test_comment_list(self):
 
         # test_user의 피드


### PR DESCRIPTION
하위 댓글들도 최상의 댓글들과 마찬가지로 최신순으로 나열되도록 `CommentListSerializer`를 수정했고, 이에 맞게끔 `newsfeed/tests.py`도 수정했습니다.