### PR TITLE
Fix/comment ordering

### DIFF
--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -734,22 +734,23 @@ class CommentTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        # 모든 계층에서 시간 오름차순으로 배열 (먼저 생성된 게 앞에)
-        self.assertEqual(data["results"][0]["content"], "depth 0")
-        self.assertEqual(data["results"][0]["children"][0]["content"], "depth 1")
-        self.assertTrue(data["results"][0]["children"][0]["is_liked"])
+        # 최상위 계층에서는 생성 순서가 (21, ..., 41), (1, ..., 20)과 같이 페이지네이션됨
+        # 그 아래 계층들에서 시간 오름차순으로 배열 (먼저 생성된 게 앞에)
+        self.assertEqual(data["results"][-1]["content"], "depth 0")
+        self.assertEqual(data["results"][-1]["children"][0]["content"], "depth 1")
+        self.assertTrue(data["results"][-1]["children"][0]["is_liked"])
         self.assertEqual(
-            data["results"][0]["children"][0]["children"][0]["content"], "depth 2"
+            data["results"][-1]["children"][0]["children"][0]["content"], "depth 2"
         )
 
         # 부모자식 관계 확인
         self.assertEqual(
-            data["results"][0]["children"][0]["parent"], data["results"][0]["id"]
+            data["results"][-1]["children"][0]["parent"], data["results"][-1]["id"]
         )
 
         # child comment 개수 확인
-        self.assertEqual(data["results"][0]["children_count"], 6)
-        self.assertEqual(len(data["results"][0]["children"]), 6)
+        self.assertEqual(data["results"][-1]["children_count"], 6)
+        self.assertEqual(len(data["results"][-1]["children"]), 6)
 
         # 페이지네이션 확인
         self.assertEqual(len(data["results"]), 20)

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -7,7 +7,7 @@ from typing import Type
 from django.db.models import Q
 from django.db import transaction
 
-from .pagination import NoticePagination, CommentPagination
+from .pagination import NoticePagination
 
 from .serializers import (
     NoticeSerializer,

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -7,7 +7,7 @@ from typing import Type
 from django.db.models import Q
 from django.db import transaction
 
-from .pagination import NoticePagination
+from .pagination import NoticePagination, CommentPagination
 
 from .serializers import (
     NoticeSerializer,
@@ -188,6 +188,19 @@ class CommentListView(ListCreateAPIView):
     permission_classes = (permissions.IsAuthenticated,)
     parser_classes = (parsers.MultiPartParser, parsers.FileUploadParser)
 
+    # ListModelMixin의 list() 메소드 오버라이딩
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        # 하나의 페이지 안에서 댓글들의 순서 역전
+        page = reversed(self.paginate_queryset(queryset))
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
     @swagger_auto_schema(
         operation_description="해당 post의 comment들 가져오기",
         responses={200: CommentListSerializer()},
@@ -195,7 +208,7 @@ class CommentListView(ListCreateAPIView):
     )
     def get(self, request, post_id=None):
         self.queryset = Comment.objects.filter(post=post_id, depth=0).order_by("-id")
-        return super().list(request)
+        return self.list(request)
 
     @swagger_auto_schema(
         operation_description="comment 생성하기",


### PR DESCRIPTION
`GET /newsfeed/{post_id}/comment/`의 response에서 댓글들이 나열되는 순서를 변경하였습니다.

- 가장 상위 계층은 다음과 같은 순서로 20개씩 페이지네이션됩니다.
    - (41, ..., 60), (21, ..., 40), (1, ..., 20)
- 하위 계층 댓글들은 최근 댓글이 뒤에 오도록 생성 시간 오름차순으로 나열됩니다.