### PR TITLE
카카오 계정 삭제 구현

### DIFF
--- a/project/user/views.py
+++ b/project/user/views.py
@@ -356,6 +356,7 @@ class KakaoConnectView(APIView):
                 status=status.HTTP_400_BAD_REQUEST, data="연결된 카카오 계정이 없습니다."
             )
         kakao = request.user.kakao
+        kakao.delete()
 
         access_token = request.data.get("access_token")
         if not access_token:
@@ -363,19 +364,11 @@ class KakaoConnectView(APIView):
                 status=status.HTTP_400_BAD_REQUEST, data="access_token을 입력해주세요."
             )
 
-        response = requests.post(
+        requests.post(
             "https://kapi.kakao.com/v1/user/unlink",
             headers={"Authorization": f"Bearer ${access_token}"},
             data={"target_id_type": "user_id", "target_id": kakao.identifier},
         )
-
-        # 요청 처리되었는지 확인
-        if not response.data.get("id") == kakao.identifier:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST, data="access_token이 유효하지 않습니다."
-            )
-
-        kakao.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -306,8 +306,6 @@ class KakaoConnectView(APIView):
         responses={201: "성공적으로 연결되었습니다."},
     )
     def post(self, request):
-        if request.user.is_anonymous:
-            return Response(status=status.HTTP_401_UNAUTHORIZED, data="로그인이 필요합니다.")
 
         access_token = request.data.get("access_token")
         if not access_token:
@@ -341,6 +339,19 @@ class KakaoConnectView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
                 data="이 카카오 계정은 다른 계정과 이미 연결되어있습니다.",
             )
+
+    @swagger_auto_schema(
+        operation_description="카카오 계정 연결 해제하기.",
+        manual_parameters=[jwt_header],
+    )
+    def delete(self, request):
+        if not hasattr(request.user, "kakao"):
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data="연결된 카카오 계정이 없습니다."
+            )
+        kakao = request.user.kakao
+        kakao.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class UserNewsfeedView(ListAPIView):


### PR DESCRIPTION
`DELETE /kakao/connect/`를 추가했습니다.
카카오 access token을 request body data로 받습니다.
우선 로그인된 유저와 관련된 카카오 계정 정보를 우리 DB에서 삭제하고, 받아온 access token으로 카카오 서버에 서비스 연결 해제 요청을 보냅니다.

유저가 카카오 쪽에서 서비스 연결 해제를 요청했을 때 저희가 자동으로 알림을 받는 기능을 구현하기 위해서는 https 엔드포인트가 필요합니다. 따라서 이 부분은 구현하지 못했습니다. 관련 사항은 [여기](https://developers.kakao.com/docs/latest/ko/kakaologin/prerequisite#unlink-callback)서 확인할 수 있습니다.