### PR TITLE
전체 게시글 보이도록 설정

### DIFF
--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -339,6 +339,7 @@ class NewsFeedTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
+        """
         # 포스트의 개수
         self.assertEqual(len(data["results"]), 2)
 
@@ -380,6 +381,7 @@ class NewsFeedTestCase(TestCase):
         self.assertEqual(
             data["results"][0]["likes"], self.test_stranger.posts.last().likes
         )
+        """
 
         # 친구가 9명일 때 피드 게시글 개수
         user = self.users[0]
@@ -584,6 +586,7 @@ class LikeTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    """
     def test_like_not_friend(self):  # 친구 아닌데 게시글 좋아요
         user = self.test_user
         post = self.test_stranger.posts.last()
@@ -595,6 +598,7 @@ class LikeTestCase(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         post.refresh_from_db()
+    """
 
     def test_like_or_dislike_myself(self):  # 자기 추천 / 비추천
         user = self.test_friend

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -42,16 +42,19 @@ class PostListView(ListCreateAPIView):
     permission_classes = (permissions.IsAuthenticated,)
 
     @swagger_auto_schema(
-        operation_description="로그인된 유저의 friend들의 post들을 최신순으로 가져오기",
+        operation_description="로그인된 유저의 friend들의 post들을 최신순으로 가져오기(현재는 모든 유저 가져오도록 설정되어 있음)",
         manual_parameters=[jwt_header],
         responses={200: MainPostSerializer()},
     )
     def get(self, request):
 
         user = request.user
+        self.queryset = Post.objects.filter(mainpost=None)
+        """
         self.queryset = Post.objects.filter(
             (Q(author__in=user.friends.all()) | Q(author=user)), mainpost=None
         )
+        """
         return super().list(request)
 
     @swagger_auto_schema(
@@ -233,6 +236,7 @@ class CommentListView(ListCreateAPIView):
         post = get_object_or_404(self.queryset, pk=post_id)
         data["post"] = post.id
 
+        """
         if (
             not user.friends.filter(id=post.author.id).exists()
             and post.author.id != user.id
@@ -240,6 +244,7 @@ class CommentListView(ListCreateAPIView):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST, data="친구 혹은 자신의 게시글이 아닙니다."
             )
+        """  # 친구만 좋아요 할 수 있도록 하는 기능 해제
         serializer = CommentSerializer(data=data, context={"user": user, "post": post})
         serializer.is_valid(raise_exception=True)
         comment = serializer.save()


### PR DESCRIPTION
- 뉴스피드 리스트에서 전체 게시글이 보이도록 했습니다. 기존 코드는 주석처리하였습니다.
- 좋아요도 전체 사람에게 가능하도록 했습니다.(이건 아예 이걸로 바꿔도 될 것 같습니다..?)
- 친구만 보였을 때 사용하던 테스트 케이스를, 임시로 주석처리했습니다. 중간총회 이후에 해제할 것 같아서,우선 그렇게 해두었습니다.