### PR TITLE
Feat/swagger authorization

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -96,7 +96,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        "HOST": "database-careerly.cq3boo3w9eua.ap-northeast-2.rds.amazonaws.com",
+        "HOST": "localhost",
         "PORT": 3306,
         "NAME": "toy_project",  # database name 변경
         "USER": "admin",
@@ -178,7 +178,16 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 AUTH_USER_MODEL = "user.User"
 
 # Swagger Configurations
-SWAGGER_SETTINGS = {"USE_SESSION_AUTH": False}
+SWAGGER_SETTINGS = {"USE_SESSION_AUTH": False,
+                    'SECURITY_DEFINITIONS': {
+                          'Bearer': {
+                                'type': 'apiKey',
+                                'name': 'Authorization',
+                                'in': 'header',
+                                'description': "로그인하여 받은 token을 `JWT {token}` 형식으로 입력해주세요."
+                          }
+                       }
+                    }
 
 # S3 설정을 위한 변수
 # AWS_xxx 의 변수들은 aws-S3, boto3 모듈을 위한 변수들이다.

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -178,16 +178,17 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 AUTH_USER_MODEL = "user.User"
 
 # Swagger Configurations
-SWAGGER_SETTINGS = {"USE_SESSION_AUTH": False,
-                    'SECURITY_DEFINITIONS': {
-                          'Bearer': {
-                                'type': 'apiKey',
-                                'name': 'Authorization',
-                                'in': 'header',
-                                'description': "로그인하여 받은 token을 `JWT {token}` 형식으로 입력해주세요."
-                          }
-                       }
-                    }
+SWAGGER_SETTINGS = {
+    "USE_SESSION_AUTH": False,
+    "SECURITY_DEFINITIONS": {
+        "Bearer": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header",
+            "description": "로그인하여 받은 token을 `JWT {token}` 형식으로 입력해주세요.",
+        }
+    },
+}
 
 # S3 설정을 위한 변수
 # AWS_xxx 의 변수들은 aws-S3, boto3 모듈을 위한 변수들이다.

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -31,13 +31,7 @@ from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema, no_body
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 
-jwt_header = openapi.Parameter(
-    "Authorization",
-    openapi.IN_HEADER,
-    type=openapi.TYPE_STRING,
-    default="JWT [put token here]",
-    required=True,
-)
+
 
 
 class PostListView(ListCreateAPIView):
@@ -48,7 +42,6 @@ class PostListView(ListCreateAPIView):
 
     @swagger_auto_schema(
         operation_description="로그인된 유저의 friend들의 post들을 최신순으로 가져오기(현재는 모든 유저 가져오도록 설정되어 있음)",
-        manual_parameters=[jwt_header],
         responses={200: MainPostSerializer()},
     )
     def get(self, request):
@@ -64,7 +57,6 @@ class PostListView(ListCreateAPIView):
 
     @swagger_auto_schema(
         operation_description="Post 작성하기",
-        manual_parameters=[jwt_header],
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
@@ -138,7 +130,6 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="게시글 수정하기",
-        manual_parameters=[jwt_header],
         responses={200: PostSerializer()},
     )
     def put(self, request, pk=None):
@@ -215,7 +206,6 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="게시글 삭제하기",
-        manual_parameters=[jwt_header],
     )
     def delete(self, request, pk=None):
 
@@ -235,7 +225,6 @@ class PostLikeView(GenericAPIView):
     @swagger_auto_schema(
         operation_description="게시물 좋아요하기",
         request_body=no_body,
-        manual_parameters=[jwt_header],
     )
     def put(self, request, post_id=None):
         user = request.user
@@ -281,7 +270,6 @@ class PostLikeView(GenericAPIView):
     @swagger_auto_schema(
         operation_description="해당 post의 좋아요 개수, 좋아요 한 유저 가져오기",
         responses={200: PostLikeSerializer()},
-        manual_parameters=[jwt_header],
     )
     def get(self, request, post_id=None):
         post = get_object_or_404(self.queryset, pk=post_id)
@@ -310,7 +298,6 @@ class CommentListView(ListCreateAPIView):
     @swagger_auto_schema(
         operation_description="해당 post의 comment들 가져오기",
         responses={200: CommentListSerializer()},
-        manual_parameters=[jwt_header],
     )
     def get(self, request, post_id=None):
         self.queryset = Comment.objects.filter(post=post_id, depth=0).order_by("-id")
@@ -320,7 +307,6 @@ class CommentListView(ListCreateAPIView):
         operation_description="comment 생성하기",
         responses={201: CommentSerializer()},
         manual_parameters=[
-            jwt_header,
             openapi.Parameter(
                 name="file",
                 in_=openapi.IN_FORM,
@@ -372,7 +358,6 @@ class CommentLikeView(GenericAPIView):
     @swagger_auto_schema(
         operation_description="comment 좋아요하기",
         request_body=no_body,
-        manual_parameters=[jwt_header],
     )
     def put(self, request, post_id=None, comment_id=None):
         user = request.user
@@ -412,7 +397,6 @@ class CommentLikeView(GenericAPIView):
     @swagger_auto_schema(
         operation_description="해당 comment의 좋아요 개수, 좋아요 한 유저 가져오기",
         responses={200: CommentLikeSerializer()},
-        manual_parameters=[jwt_header],
     )
     def get(self, request, post_id=None, comment_id=None):
         comment = get_object_or_404(self.queryset, pk=comment_id, post=post_id)
@@ -484,7 +468,6 @@ class NoticeView(GenericAPIView):
     @swagger_auto_schema(
         operation_description="알림 읽기",
         responses={200: NoticelistSerializer()},
-        manual_parameters=[jwt_header],
     )
     def get(self, request, notice_id=None):
         notice = get_object_or_404(request.user.notices, id=notice_id)
@@ -497,7 +480,6 @@ class NoticeView(GenericAPIView):
 
     @swagger_auto_schema(
         operation_description="알림 삭제하기",
-        manual_parameters=[jwt_header],
     )
     def delete(self, request, notice_id=None):
 
@@ -515,7 +497,6 @@ class NoticeListView(ListAPIView):
     @swagger_auto_schema(
         operation_description="알림 목록 불러오기",
         responses={200: NoticelistSerializer(many=True)},
-        manual_parameters=[jwt_header],
     )
     def get(self, request):
         notices = request.user.notices.all()

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -32,8 +32,6 @@ from drf_yasg.utils import swagger_auto_schema, no_body
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 
 
-
-
 class PostListView(ListCreateAPIView):
 
     serializer_class = MainPostSerializer

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -216,6 +216,11 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
             )
         return super().destroy(request, pk=pk)
 
+    # 부모의 patch 메서드를 drf-yasg가 읽지 않게 오버리이딩
+    @swagger_auto_schema(auto_schema=None)
+    def patch(self, request, *args, **kwargs):
+        return Response(status.HTTP_204_NO_CONTENT)
+
 
 class PostLikeView(GenericAPIView):
     serializer_class = PostSerializer

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -48,9 +48,6 @@ from newsfeed.views import NoticeCreate
 User = get_user_model()
 
 
-
-
-
 class UserSignUpView(APIView):
     permission_classes = (permissions.AllowAny,)
 

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -22,7 +22,6 @@ from drf_yasg import openapi
 from config.settings import get_secret
 from user.models import KakaoId, Company, University, FriendRequest
 from rest_framework.viewsets import GenericViewSet
-from newsfeed.views import jwt_header
 from user.models import KakaoId, FriendRequest
 from user.pagination import UserPagination
 from user.serializers import (
@@ -49,13 +48,7 @@ from newsfeed.views import NoticeCreate
 User = get_user_model()
 
 
-jwt_header = openapi.Parameter(
-    "Authorization",
-    openapi.IN_HEADER,
-    type=openapi.TYPE_STRING,
-    default="JWT [put token here]",
-    required=True,
-)
+
 
 
 class UserSignUpView(APIView):
@@ -117,7 +110,6 @@ class UserFriendRequestView(ListCreateAPIView):
     @swagger_auto_schema(
         operation_description="친구 요청 목록 불러오기",
         responses={200: FriendRequestCreateSerializer(many=True)},
-        manual_parameters=[jwt_header],
     )
     def get(self, request):
         self.queryset = self.queryset.filter(receiver=request.user)
@@ -126,7 +118,6 @@ class UserFriendRequestView(ListCreateAPIView):
     @swagger_auto_schema(
         operation_description="친구 요청 보내기",
         responses={201: FriendRequestCreateSerializer()},
-        manual_parameters=[jwt_header],
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={"receiver": openapi.Schema(type=openapi.TYPE_NUMBER)},
@@ -147,7 +138,6 @@ class UserFriendRequestView(ListCreateAPIView):
 
     @swagger_auto_schema(
         operation_description="친구 요청 수락하기",
-        manual_parameters=[jwt_header],
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
@@ -170,7 +160,6 @@ class UserFriendRequestView(ListCreateAPIView):
 
     @swagger_auto_schema(
         operation_description="친구 요청 삭제하기",
-        manual_parameters=[jwt_header],
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
@@ -199,7 +188,6 @@ class UserFriendDeleteView(APIView):
 
     @swagger_auto_schema(
         operation_description="친구 삭제하기",
-        manual_parameters=[jwt_header],
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
@@ -229,7 +217,6 @@ class UserSearchListView(ListAPIView):
     @swagger_auto_schema(
         operation_description="유저 검색하기",
         manual_parameters=[
-            jwt_header,
             openapi.Parameter(
                 "q",
                 openapi.IN_QUERY,
@@ -302,7 +289,6 @@ class KakaoConnectView(APIView):
 
     @swagger_auto_schema(
         operation_description="카카오 계정 연결하기",
-        manual_parameters=[jwt_header],
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
@@ -348,7 +334,6 @@ class KakaoConnectView(APIView):
 
     @swagger_auto_schema(
         operation_description="카카오 계정 연결 해제하기.",
-        manual_parameters=[jwt_header],
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,
             properties={
@@ -386,7 +371,6 @@ class UserNewsfeedView(ListAPIView):
 
     @swagger_auto_schema(
         operation_description="선택된 유저가 작성한 게시글을 가져오기",
-        manual_parameters=[jwt_header],
         responses={200: MainPostSerializer()},
     )
     def get(self, request, user_id=None):
@@ -403,7 +387,6 @@ class UserFriendListView(ListAPIView):
 
     @swagger_auto_schema(
         operation_description="선택된 유저의 친구들을 가져오기",
-        manual_parameters=[jwt_header],
         responses={200: UserSerializer()},
     )
     def get(self, request, user_id=None):
@@ -420,7 +403,6 @@ class UserProfileView(RetrieveUpdateAPIView):
 
     @swagger_auto_schema(
         operation_description="유저의 프로필 정보 가져오기",
-        manual_parameters=[jwt_header],
         responses={200: UserProfileSerializer()},
     )
     def get(self, request, pk=None):
@@ -429,7 +411,6 @@ class UserProfileView(RetrieveUpdateAPIView):
     @swagger_auto_schema(
         operation_description="프로필 정보 편집하기",
         manual_parameters=[
-            jwt_header,
             openapi.Parameter(
                 name="profile_image",
                 in_=openapi.IN_FORM,
@@ -473,7 +454,6 @@ class CompanyCreateView(CreateAPIView):
 
     @swagger_auto_schema(
         operation_description="회사 정보 생성하기",
-        manual_parameters=[jwt_header],
         responses={200: CompanySerializer()},
     )
     def post(self, request):
@@ -494,7 +474,6 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="회사 정보 가져오기",
-        manual_parameters=[jwt_header],
         responses={200: CompanySerializer()},
     )
     def get(self, request, pk=None):
@@ -502,7 +481,6 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="회사 정보 수정하기",
-        manual_parameters=[jwt_header],
         responses={200: CompanySerializer()},
     )
     def put(self, request, pk=None):
@@ -515,7 +493,6 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="회사 정보 삭제하기",
-        manual_parameters=[jwt_header],
     )
     def delete(self, request, pk=None):
         company = get_object_or_404(Company, pk=pk)
@@ -538,7 +515,6 @@ class UniversityCreateView(CreateAPIView):
 
     @swagger_auto_schema(
         operation_description="대학 정보 수정하기",
-        manual_parameters=[jwt_header],
         responses={200: UniversitySerializer()},
     )
     def post(self, request):
@@ -559,7 +535,6 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="대학 정보 가져오기",
-        manual_parameters=[jwt_header],
         responses={200: UniversitySerializer()},
     )
     def get(self, request, pk=None):
@@ -567,7 +542,6 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="대학 정보 수정하기",
-        manual_parameters=[jwt_header],
         responses={200: UniversitySerializer()},
     )
     def put(self, request, pk=None):
@@ -580,7 +554,6 @@ class UniversityView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="대학 정보 삭제하기",
-        manual_parameters=[jwt_header],
     )
     def delete(self, request, pk=None):
         university = get_object_or_404(University, pk=pk)


### PR DESCRIPTION
<h2>Swagger에서 authorization 방법 변경</h2>  

요청마다 Authorization 헤더를 일일이 붙여넣어야 했던 원래의 방식에서, swagger 페이지 우측 상단의 authorize 메뉴를 활용할 수 있도록 바꾸었습니다.    

우측 상단의 authorize 버튼을 누르고, `JWT {token}` 형식으로 값을 입력하시면 됩니다.  

토큰을 받아올 때마다 매번 `POST /login/` 요청을 날려야 한다는 점은 변함없지만, 그래도 이제는 토큰을 한 번만 입력하면 모든 요청에 자동으로 authorization header가 첨부될 겁니다.  

다만 이제 여러 토큰을 동시에 사용하는 것(게시물을 쓰는 API에는 철수의 토큰을 넣어두는 동시에 게시물을 불러오는 API에는 영희의 토큰을 넣는 등)이 불가능해질 것이기 때문에, 이전의 방식이 편하신 것 같다면 바로 말씀 부탁드립니다!

<br></br>

<h2>기타 변경사항</h2>    

-  `PATCH /newsfeed/{id}/`가 스웨거에서 표시되지 않도록 `PostUpdateView`를 수정했습니다.
-  Github Actions에서 테스트가 빨리 진행되도록 `settings.py`에서 DB host를 localhost으로 변경했습니다.