### PR TITLE
친구 요청 수정

### DIFF
--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -309,9 +309,7 @@ class FriendRequestCreateSerializer(serializers.ModelSerializer):
             sender.received_friend_request.filter(sender=receiver).exists()
         ):
             raise serializers.ValidationError("이 유저에게 이미 친구 요청을 받았습니다.")
-        if (
-            sender.sent_friend_request.filter(receiver=receiver).exists()
-        ):
+        if sender.sent_friend_request.filter(receiver=receiver).exists():
             raise serializers.ValidationError("이미 이 유저에게 친구 요청을 보냈습니다.")
 
         if sender == receiver:

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -297,9 +297,7 @@ class FriendRequestCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         sender = validated_data.get("sender")
         receiver = validated_data.get("receiver")
-        friend_request, is_created = FriendRequest.objects.update_or_create(
-            sender=sender, receiver=receiver, defaults={"created": datetime.now()}
-        )
+        friend_request = FriendRequest.objects.create(sender=sender, receiver=receiver)
         return friend_request
 
     def validate(self, data):
@@ -308,11 +306,13 @@ class FriendRequestCreateSerializer(serializers.ModelSerializer):
         if sender.friends.filter(pk=receiver.id).exists():
             raise serializers.ValidationError("이미 친구입니다.")
         if (
-            FriendRequest.objects.all()
-            .filter(sender=receiver, receiver=sender)
-            .exists()
+            sender.received_friend_request.filter(sender=receiver).exists()
         ):
             raise serializers.ValidationError("이 유저에게 이미 친구 요청을 받았습니다.")
+        if (
+            sender.sent_friend_request.filter(receiver=receiver).exists()
+        ):
+            raise serializers.ValidationError("이미 이 유저에게 친구 요청을 보냈습니다.")
 
         if sender == receiver:
             raise serializers.ValidationError("자신에게 친구 요청을 보낼 수 없습니다.")

--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -939,6 +939,9 @@ class FriendTestCase(TestCase):
         for sender in cls.senders:
             FriendRequestFactory.create(sender=sender, receiver=cls.test_user)
 
+        cls.receiver = UserFactory.create()
+        FriendRequestFactory.create(sender=cls.test_user, receiver=cls.receiver)
+
         cls.test_stranger = UserFactory.create()
 
     def test_get_friend_request(self):
@@ -1006,6 +1009,16 @@ class FriendTestCase(TestCase):
             HTTP_AUTHORIZATION=user_token,
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # 자신이 이미 친구 요청을 보낸 대상에게 다시 친구 요청
+        response = self.client.post(
+            "/api/v1/friend/request/",
+            data={"receiver": self.receiver.id},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
         # 유효하지 않은 유저 id에 친구 요청
         response = self.client.post(
             "/api/v1/friend/request/",

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -219,7 +219,7 @@ class UserSearchListView(ListAPIView):
                 openapi.IN_QUERY,
                 description="search key",
                 type=openapi.TYPE_STRING,
-                required=True
+                required=True,
             ),
         ],
         responses={200: UserMutualFriendsSerializer(many=True)},
@@ -227,7 +227,9 @@ class UserSearchListView(ListAPIView):
     def get(self, request):
         search_key = request.GET.get("q")
         if not search_key:
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="search key를 입력해주세요")
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data="search key를 입력해주세요"
+            )
         self.queryset = User.objects.filter(username__icontains=search_key)
         return super().list(request)
 

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -219,14 +219,15 @@ class UserSearchListView(ListAPIView):
                 openapi.IN_QUERY,
                 description="search key",
                 type=openapi.TYPE_STRING,
+                required=True
             ),
         ],
         responses={200: UserMutualFriendsSerializer(many=True)},
     )
     def get(self, request):
-        user = request.user
-        request.data["request_user"] = user
         search_key = request.GET.get("q")
+        if not search_key:
+            return Response(status=status.HTTP_400_BAD_REQUEST, data="search key를 입력해주세요")
         self.queryset = User.objects.filter(username__icontains=search_key)
         return super().list(request)
 


### PR DESCRIPTION
<h2>변경된 사항</h2>  

- `FriendRequestCreateSerializer`: 자신이 한 번 친구 요청을 보낸 대상에게 다시 친구 요청을 보낼 수 없도록 수정하였습니다  
    - 해당 케이스를 걸러내도록 `validate` 메소드를 수정했습니다.
    -  `create` 메소드에서 update_or_create()을 create()으로 수정했습니다.  
    - 관련 테스트케이스를 추가했습니다.

- `UserSearchListView`:
    - `GET /search/`에서 query parameter가 비어있으면 500 오류가 뜨는 것을 확인하고, 해당 케이스를 핸들링하도록 를 수정했습니다.
    - 불필요한 `data['request_user']` 부분을 삭제했습니다.  
