### PR TITLE
친구 요청 수정

### DIFF
--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -280,8 +280,7 @@ class NoticeTestCase(TestCase):
         stranger_token = "JWT " + jwt_token_of(stranger)
 
         response = self.client.post(
-            "/api/v1/friend/request/",
-            data={"receiver": self.test_user.id},
+            f"/api/v1/friend/request/{self.test_user.id}/",
             content_type="application/json",
             HTTP_AUTHORIZATION=stranger_token,
         )
@@ -298,7 +297,7 @@ class NoticeTestCase(TestCase):
 
         # 친구수락
         response = self.client.put(
-            "/api/v1/friend/request/",
+            f"/api/v1/friend/request/{stranger.id}/",
             data={"sender": stranger.id},
             content_type="application/json",
             HTTP_AUTHORIZATION=self.user_token,

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -305,9 +305,7 @@ class FriendRequestCreateSerializer(serializers.ModelSerializer):
         sender = data["sender"]
         if sender.friends.filter(pk=receiver.id).exists():
             raise serializers.ValidationError("이미 친구입니다.")
-        if (
-            sender.received_friend_request.filter(sender=receiver).exists()
-        ):
+        if sender.received_friend_request.filter(sender=receiver).exists():
             raise serializers.ValidationError("이 유저에게 이미 친구 요청을 받았습니다.")
         if sender.sent_friend_request.filter(receiver=receiver).exists():
             raise serializers.ValidationError("이미 이 유저에게 친구 요청을 보냈습니다.")

--- a/project/user/urls.py
+++ b/project/user/urls.py
@@ -16,7 +16,7 @@ from .views import (
     CompanyCreateView,
     CompanyView,
     UniversityCreateView,
-    UniversityView,
+    UniversityView, UserFriendRequestListView,
 )
 from django.conf import settings
 from django.conf.urls.static import static
@@ -53,8 +53,11 @@ urlpatterns = [
         "user/university/<int:pk>/", UniversityView.as_view(), name="university"
     ),  # /api/v1/user/university/{university_id}/
     path(
-        "friend/request/", UserFriendRequestView.as_view(), name="friend_request"
+        "friend/request/", UserFriendRequestListView.as_view(), name="friend_request_list"
     ),  # /api/v1/friend/request/
+    path(
+        "friend/request/<int:pk>/", UserFriendRequestView.as_view(), name="friend_request"
+    ),
     path("friend/", UserFriendDeleteView.as_view(), name="friend"),  # /api/v1/friend/
     path("search/", UserSearchListView.as_view(), name="search"),  # /api/v1/search/
 ]

--- a/project/user/urls.py
+++ b/project/user/urls.py
@@ -16,7 +16,8 @@ from .views import (
     CompanyCreateView,
     CompanyView,
     UniversityCreateView,
-    UniversityView, UserFriendRequestListView,
+    UniversityView,
+    UserFriendRequestListView,
 )
 from django.conf import settings
 from django.conf.urls.static import static
@@ -53,10 +54,14 @@ urlpatterns = [
         "user/university/<int:pk>/", UniversityView.as_view(), name="university"
     ),  # /api/v1/user/university/{university_id}/
     path(
-        "friend/request/", UserFriendRequestListView.as_view(), name="friend_request_list"
+        "friend/request/",
+        UserFriendRequestListView.as_view(),
+        name="friend_request_list",
     ),  # /api/v1/friend/request/
     path(
-        "friend/request/<int:pk>/", UserFriendRequestView.as_view(), name="friend_request"
+        "friend/request/<int:pk>/",
+        UserFriendRequestView.as_view(),
+        name="friend_request",
     ),
     path("friend/", UserFriendDeleteView.as_view(), name="friend"),  # /api/v1/friend/
     path("search/", UserSearchListView.as_view(), name="search"),  # /api/v1/search/

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -150,9 +150,7 @@ class UserFriendRequestView(APIView):
         serializer.is_valid(raise_exception=True)
         serializer.accept(serializer.validated_data)
 
-        NoticeCreate(
-            user=receiver, content="FriendAccept", receiver=sender.id
-        )
+        NoticeCreate(user=receiver, content="FriendAccept", receiver=sender.id)
 
         return Response(status=status.HTTP_200_OK, data="수락 완료되었습니다.")
 
@@ -168,7 +166,9 @@ class UserFriendRequestView(APIView):
         elif request.user.received_friend_request.filter(sender=target_user):
             data = {"sender": target_user.id, "receiver": request.user.id}
         else:
-            return Response(status=status.HTTP_400_BAD_REQUEST, data="해당 유저에게 보내거나 받은 친구 요청이 없습니다.")
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST, data="해당 유저에게 보내거나 받은 친구 요청이 없습니다."
+            )
 
         serializer = FriendRequestAcceptDeleteSerializer(data=data)
         serializer.is_valid(raise_exception=True)

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -99,7 +99,7 @@ class UserLogoutView(APIView):
         return Response("로그아웃 되었습니다.", status=status.HTTP_200_OK)
 
 
-class UserFriendRequestView(ListCreateAPIView):
+class UserFriendRequestListView(ListAPIView):
     serializer_class = FriendRequestCreateSerializer
     queryset = FriendRequest.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
@@ -112,67 +112,65 @@ class UserFriendRequestView(ListCreateAPIView):
         self.queryset = self.queryset.filter(receiver=request.user)
         return super().list(request)
 
+
+class UserFriendRequestView(APIView):
+    queryset = User.objects.all()
+    permission_classes = (permissions.IsAuthenticated,)
+
     @swagger_auto_schema(
-        operation_description="친구 요청 보내기",
+        operation_description="해당 유저에게 친구 요청 보내기",
         responses={201: FriendRequestCreateSerializer()},
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={"receiver": openapi.Schema(type=openapi.TYPE_NUMBER)},
-        ),
     )
-    def post(self, request):
-        request.data["sender"] = request.user.id
-        serializer = self.serializer_class(data=request.data)
+    def post(self, request, pk=None):
+        sender = request.user
+        receiver = get_object_or_404(self.queryset, pk=pk)
+
+        data = {"sender": sender.id, "receiver": receiver.id}
+        serializer = FriendRequestCreateSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
         NoticeCreate(
-            user=request.user,
+            user=sender,
             content="FriendRequest",
-            receiver=request.data["receiver"],
+            receiver=receiver.id,
         )
 
         return Response(status=status.HTTP_201_CREATED, data=serializer.data)
 
     @swagger_auto_schema(
-        operation_description="친구 요청 수락하기",
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                "sender": openapi.Schema(type=openapi.TYPE_NUMBER),
-            },
-        ),
+        operation_description="해당 유저가 보낸 친구 요청 수락하기",
         responses={200: "수락 완료되었습니다."},
     )
-    def put(self, request):
-        request.data["receiver"] = request.user.id
-        serializer = FriendRequestAcceptDeleteSerializer(data=request.data)
+    def put(self, request, pk=None):
+        sender = get_object_or_404(self.queryset, pk=pk)
+        receiver = request.user
+
+        data = {"sender": sender.id, "receiver": receiver.id}
+        serializer = FriendRequestAcceptDeleteSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         serializer.accept(serializer.validated_data)
 
         NoticeCreate(
-            user=request.user, content="FriendAccept", receiver=request.data["sender"]
+            user=receiver, content="FriendAccept", receiver=sender.id
         )
 
         return Response(status=status.HTTP_200_OK, data="수락 완료되었습니다.")
 
     @swagger_auto_schema(
-        operation_description="친구 요청 삭제하기",
-        request_body=openapi.Schema(
-            type=openapi.TYPE_OBJECT,
-            properties={
-                "sender": openapi.Schema(type=openapi.TYPE_NUMBER),
-                "receiver": openapi.Schema(type=openapi.TYPE_NUMBER),
-            },
-        ),
+        operation_description="해당 유저에게 자신이 보냈거나 받은 친구 요청 삭제하기",
         responses={204: "삭제 완료되었습니다."},
     )
-    def delete(self, request):
-        user = request.user
-        if (user.id != request.data.get("sender")) and (
-            user.id != request.data.get("receiver")
-        ):
-            return Response(status=status.HTTP_403_FORBIDDEN, data="권한이 없습니다.")
-        serializer = FriendRequestAcceptDeleteSerializer(data=request.data)
+    def delete(self, request, pk=None):
+        target_user = get_object_or_404(self.queryset, pk=pk)
+
+        if request.user.sent_friend_request.filter(receiver=target_user):
+            data = {"sender": request.user.id, "receiver": target_user.id}
+        elif request.user.received_friend_request.filter(sender=target_user):
+            data = {"sender": target_user.id, "receiver": request.user.id}
+        else:
+            return Response(status=status.HTTP_400_BAD_REQUEST, data="해당 유저에게 보내거나 받은 친구 요청이 없습니다.")
+
+        serializer = FriendRequestAcceptDeleteSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         serializer.delete(serializer.validated_data)
 


### PR DESCRIPTION
<h2>친구 요청을 전송, 수락, 삭제할 때 user의 id를 path variable로 받도록 수정</h2>  

원래는 `PUT, POST, DELETE /friend/request/`으로 request를 보낼 때 request body에 상대방 유저의 id를 넣어 보내는 방식으로 구현했는데,  
이제는 `PUT, POST, DELETE /friend/request/{user_id}/`와 같은 식으로 변경되었습니다.  

`DELETE /friend/request/{user_id}/`으로 request를 보내면 user_id에 해당되는 유저에게 자신이 받았거나 보낸 친구 요청을 삭제할 수 있습니다.  마찬가지로 `PUT`을 통해 친구 요청을 수락, `POST`를 통해 친구 요청을 전송할 수 있습니다.
