### PR TITLE
프로필 회사/학교 나가는 날짜에 빈 스트링 허용

### DIFF
--- a/project/secret_gen.py
+++ b/project/secret_gen.py
@@ -6,6 +6,6 @@ data = {
     "KAKAO_APP_KEY": "",
     "AWS_SECRET_ACCESS_KEY": "",
     "AWS_ACCESS_KEY_ID": "",
-    "DATABASE_HOST": "localhost"
+    "DATABASE_HOST": "localhost",
 }
 f.write(json.dumps(data))

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -184,6 +184,11 @@ class CompanySerializer(serializers.ModelSerializer):
         instance.save()
         return instance
 
+    def to_internal_value(self, data):
+        if data.get("leave_date") == "":
+            data["leave_date"] = None
+        return super().to_internal_value(data)
+
 
 class UniversitySerializer(serializers.ModelSerializer):
     class Meta:
@@ -225,6 +230,11 @@ class UniversitySerializer(serializers.ModelSerializer):
         )
         instance.save()
         return instance
+
+    def to_internal_value(self, data):
+        if data.get("graduate_date") == "":
+            data["graduate_date"] = None
+        return super().to_internal_value(data)
 
 
 class UserPutSwaggerSerializer(serializers.Serializer):


### PR DESCRIPTION
- to_internal_value를 오버라이딩해, 빈 스트링은 None으로 처리되도록 했습니다.
- 프로필에서 회사나 대학 정보를 수정할 때, 그만둔 날짜를 지우려고 할 때 빈 스트링으로 지워지는 것을 확인하는 테스트케이스를 보충했습니다.