### PR TITLE
Feat/comment update delete

### DIFF
--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -234,10 +234,6 @@ class CommentPostSwaggerSerializer(serializers.Serializer):
     )
 
 
-class CommentUpdateSwaggerSerializer(serializers.Serializer):
-    content = serializers.CharField(required=False)
-
-
 class CommentSerializer(serializers.ModelSerializer):
     is_liked = serializers.SerializerMethodField()
 

--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -227,11 +227,15 @@ class CommentLikeSerializer(serializers.ModelSerializer):
         return UserSerializer(comment.likeusers, many=True).data
 
 
-class CommentSwaggerSerializer(serializers.Serializer):
+class CommentPostSwaggerSerializer(serializers.Serializer):
     content = serializers.CharField(required=True)
     parent = serializers.IntegerField(
         required=False, help_text="부모 댓글의 id. Depth가 0인 경우 해당 필드를 비워두세요."
     )
+
+
+class CommentUpdateSwaggerSerializer(serializers.Serializer):
+    content = serializers.CharField(required=False)
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -1668,3 +1668,72 @@ class CommentTestCase(TestCase):
         # DELETE, 좋아요 취소 반영됐는지 확인
         self.assertEqual(data["likes"], 0)
         self.assertEqual(self.depth_zero.likes, 0)
+
+    def test_comment_edit(self):
+        friend_token = "JWT " + jwt_token_of(self.test_friend)
+
+        data = {"content": "edited"}
+
+        response = self.client.put(
+            f"/api/v1/newsfeed/{self.my_post.id}/{self.depth_zero.id}/",
+            data=data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=friend_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["content"], "edited")
+
+        # content가 비어있는 경우
+        response = self.client.put(
+            f"/api/v1/newsfeed/{self.my_post.id}/{self.depth_zero.id}/",
+            data={"content": ""},
+            content_type="application/json",
+            HTTP_AUTHORIZATION=friend_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # 자신의 댓글이 아닌 경우
+        response = self.client.put(
+            f"/api/v1/newsfeed/{self.my_post.id}/{self.depth_zero.id}/",
+            data=data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION="JWT " + jwt_token_of(self.test_user),
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # 존재하지 않는 댓글일 경우
+        response = self.client.put(
+            f"/api/v1/newsfeed/{self.my_post.id}/10000000/",
+            data=data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=friend_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_comment_delete(self):
+        friend_token = "JWT " + jwt_token_of(self.test_friend)
+
+        # 자신의 댓글이 아닌 경우
+        response = self.client.delete(
+            f"/api/v1/newsfeed/{self.my_post.id}/{self.depth_zero.id}/",
+            HTTP_AUTHORIZATION="JWT " + jwt_token_of(self.test_user),
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # 존재하지 않는 댓글일 경우
+        response = self.client.delete(
+            f"/api/v1/newsfeed/{self.my_post.id}/10000000/",
+            HTTP_AUTHORIZATION=friend_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # 댓글 삭제
+        response = self.client.delete(
+            f"/api/v1/newsfeed/{self.my_post.id}/{self.depth_zero.id}/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=friend_token,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -639,7 +639,7 @@ class NewsFeedTestCase(TestCase):
             "content": "메인 포스트입니다. (수정됨)",
             "subposts": ["첫번째 포스트입니다. (수정됨)", "두번째 포스트입니다. (수정됨)", "세번째 포스트입니다. (수정됨)"],
             "subposts_id": [subpost_1, subpost_2, subpost_3],
-            "removed_subposts": subpost_1,
+            "removed_subposts_id": subpost_1,
         }
         content = encode_multipart("BoUnDaRyStRiNg", data)
 
@@ -703,7 +703,7 @@ class NewsFeedTestCase(TestCase):
                 test_image,
             ],
             "subposts_id": [subpost_2, subpost_3, subpost_4],
-            "removed_subposts": [subpost_2, subpost_3],
+            "removed_subposts_id": [subpost_2, subpost_3],
         }
         content = encode_multipart("BoUnDaRyStRiNg", data)
         response = self.client.put(

--- a/project/newsfeed/tests.py
+++ b/project/newsfeed/tests.py
@@ -1735,5 +1735,3 @@ class CommentTestCase(TestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-

--- a/project/newsfeed/urls.py
+++ b/project/newsfeed/urls.py
@@ -6,7 +6,8 @@ from .views import (
     CommentListView,
     CommentLikeView,
     NoticeView,
-    NoticeListView, CommentUpdateDeleteView,
+    NoticeListView,
+    CommentUpdateDeleteView,
 )
 from rest_framework.routers import SimpleRouter
 from django.conf import settings

--- a/project/newsfeed/urls.py
+++ b/project/newsfeed/urls.py
@@ -6,7 +6,7 @@ from .views import (
     CommentListView,
     CommentLikeView,
     NoticeView,
-    NoticeListView,
+    NoticeListView, CommentUpdateDeleteView,
 )
 from rest_framework.routers import SimpleRouter
 from django.conf import settings
@@ -16,6 +16,7 @@ urlpatterns = [
     path("newsfeed/", PostListView.as_view()),
     path("newsfeed/<int:pk>/", PostUpdateView.as_view()),
     path("newsfeed/<int:post_id>/comment/", CommentListView.as_view()),
+    path("newsfeed/<int:post_id>/<int:comment_id>/", CommentUpdateDeleteView.as_view()),
     path("newsfeed/<int:post_id>/like/", PostLikeView.as_view()),
     path("newsfeed/<int:post_id>/<int:comment_id>/like/", CommentLikeView.as_view()),
     path("newsfeed/notices/", NoticeListView.as_view()),

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -65,8 +65,10 @@ class PostListView(ListCreateAPIView):
                     type=openapi.TYPE_STRING, description="Post Content"
                 ),
                 "scope": openapi.Schema(
-                    type=openapi.TYPE_NUMBER, description="공개범위 설정: 1(자기 자신), 2(친구), 3(전체 공개)", default=3
-                )
+                    type=openapi.TYPE_NUMBER,
+                    description="공개범위 설정: 1(자기 자신), 2(친구), 3(전체 공개)",
+                    default=3,
+                ),
             },
         ),
         responses={201: PostSerializer()},
@@ -126,8 +128,7 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
     parser_classes = (MultiPartParser, FormParser, JSONParser)
 
     @swagger_auto_schema(
-        operation_description="Post 조회하기",
-        responses={200: PostSerializer()}
+        operation_description="Post 조회하기", responses={200: PostSerializer()}
     )
     def get(self, request, pk=None):
 
@@ -159,21 +160,29 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
             type=openapi.TYPE_OBJECT,
             properties={
                 "content": openapi.Schema(
-                    type=openapi.TYPE_STRING, description="main post의 content",
+                    type=openapi.TYPE_STRING,
+                    description="main post의 content",
                 ),
                 "subposts": openapi.Schema(
-                    type=openapi.TYPE_ARRAY, description="subpost들의 content의 array", items=openapi.TYPE_STRING
+                    type=openapi.TYPE_ARRAY,
+                    description="subpost들의 content의 array",
+                    items=openapi.TYPE_STRING,
                 ),
                 "subposts_id": openapi.Schema(
-                    type=openapi.TYPE_ARRAY, description="기존 subpost들의 id의 array", items=openapi.TYPE_NUMBER
+                    type=openapi.TYPE_ARRAY,
+                    description="기존 subpost들의 id의 array",
+                    items=openapi.TYPE_NUMBER,
                 ),
                 "removed_subposts_id": openapi.Schema(
-                    type=openapi.TYPE_ARRAY, description="삭제될 subpost들의 id의 array", items=openapi.TYPE_NUMBER
+                    type=openapi.TYPE_ARRAY,
+                    description="삭제될 subpost들의 id의 array",
+                    items=openapi.TYPE_NUMBER,
                 ),
                 "scope": openapi.Schema(
-                    type=openapi.TYPE_NUMBER, description="공개범위 설정: 1(자기 자신), 2(친구), 3(전체 공개)", default=3
+                    type=openapi.TYPE_NUMBER,
+                    description="공개범위 설정: 1(자기 자신), 2(친구), 3(전체 공개)",
+                    default=3,
                 ),
-
             },
         ),
         responses={200: PostSerializer()},
@@ -426,13 +435,15 @@ class CommentUpdateDeleteView(APIView):
                 "content": openapi.Schema(
                     type=openapi.TYPE_STRING, description="Comment Content"
                 ),
-            }
-        )
+            },
+        ),
     )
     def put(self, request, post_id=None, comment_id=None):
         comment = get_object_or_404(self.queryset, pk=comment_id, post=post_id)
         if comment.author != request.user:
-            return Response(status=status.HTTP_403_FORBIDDEN, data="다른 유저의 댓글을 수정할 수 없습니다.")
+            return Response(
+                status=status.HTTP_403_FORBIDDEN, data="다른 유저의 댓글을 수정할 수 없습니다."
+            )
 
         content = request.data.get("content")
 
@@ -450,7 +461,9 @@ class CommentUpdateDeleteView(APIView):
         comment = get_object_or_404(self.queryset, pk=comment_id, post=post_id)
 
         if comment.author != request.user:
-            return Response(status=status.HTTP_403_FORBIDDEN, data="다른 유저의 댓글을 삭제할 수 없습니다.")
+            return Response(
+                status=status.HTTP_403_FORBIDDEN, data="다른 유저의 댓글을 삭제할 수 없습니다."
+            )
         comment.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -64,12 +64,6 @@ class PostListView(ListCreateAPIView):
                 "content": openapi.Schema(
                     type=openapi.TYPE_STRING, description="Post Content"
                 ),
-                "files": openapi.Schema(
-                    type=openapi.TYPE_ARRAY,
-                    description='"content", "file"을 key로 가지는 Dictionary들의 Array',
-                    default=[],
-                    items=openapi.TYPE_OBJECT,
-                ),
                 "scope": openapi.Schema(
                     type=openapi.TYPE_NUMBER, description="공개범위 설정: 1(자기 자신), 2(친구), 3(전체 공개)", default=3
                 )
@@ -161,6 +155,27 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
 
     @swagger_auto_schema(
         operation_description="게시글 수정하기",
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "content": openapi.Schema(
+                    type=openapi.TYPE_STRING, description="main post의 content",
+                ),
+                "subposts": openapi.Schema(
+                    type=openapi.TYPE_ARRAY, description="subpost들의 content의 array", items=openapi.TYPE_STRING
+                ),
+                "subposts_id": openapi.Schema(
+                    type=openapi.TYPE_ARRAY, description="기존 subpost들의 id의 array", items=openapi.TYPE_NUMBER
+                ),
+                "removed_subposts_id": openapi.Schema(
+                    type=openapi.TYPE_ARRAY, description="삭제될 subpost들의 id의 array", items=openapi.TYPE_NUMBER
+                ),
+                "scope": openapi.Schema(
+                    type=openapi.TYPE_NUMBER, description="공개범위 설정: 1(자기 자신), 2(친구), 3(전체 공개)", default=3
+                ),
+
+            },
+        ),
         responses={200: PostSerializer()},
     )
     def put(self, request, pk=None):
@@ -183,7 +198,7 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
         subposts = request.data.getlist("subposts_id")
         cnt = post.subposts.count()
         scope = request.data.get("scope")
-        removed = request.data.getlist("removed_subposts")
+        removed = request.data.getlist("removed_subposts_id")
 
         if cnt != len(set(subposts)):
             return Response(

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -68,6 +68,9 @@ class PostListView(ListCreateAPIView):
                     default=[],
                     items=openapi.TYPE_OBJECT,
                 ),
+                "scope": openapi.Schema(
+                    type=openapi.TYPE_NUMBER, description="공개범위 설정: 1(자기 자신), 2(친구), 3(전체 공개)", default=3
+                )
             },
         ),
         responses={201: PostSerializer()},
@@ -126,6 +129,10 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
     permission_classes = (permissions.IsAuthenticated,)
     parser_classes = (MultiPartParser, FormParser, JSONParser)
 
+    @swagger_auto_schema(
+        operation_description="Post 조회하기",
+        responses={200: PostSerializer()}
+    )
     def get(self, request, pk=None):
 
         post = get_object_or_404(Post, pk=pk)


### PR DESCRIPTION
<h2>댓글 수정, 삭제 구현했습니다!</h2>   

**1. `PUT /newsfeed/{post_id}/{comment_id}/`**
- request body에 `content`를 받고 댓글 내용을 수정합니다.
- 원래는 댓글의 파일도 수정하거나 삭제할 수 있도록 코드를 짰지만, 다시 확인해보니 페이스북에서는 댓글 내용만 수정할 수 있어서 페이스북에 맞게 구현헀습니다... 😭😭 

**2. `DELETE /newsfeed/{post_id}/{comment_id}/`**
- url의 path에 해당하는 댓글을 삭제합니다.

**3. 다른 변경사항**
- 댓글 수정, 삭제에 대한 테스트케이스 추가  
- 게시물 생성, 게시물 불러오기, 게시물 수정에 대한 스웨거 데코레이터 추가  
    - 스웨거에 동시에 여러 개의 파일을 올릴 수 있는 방법을 찾지 못해서 스웨거로는 게시물 생성 및 수정 시 파일을 첨부할 수 없습니다... ㅠ
    - request body에 받아올 필드를 `@swagger_auto_schema`데코레이터 안에 명시해두었는데, 제가 누락한 필드가 있거나, 설명이 옳지 않은 경우 말씀해주시기 바랍니다! (특히 `PostUpdateView.put()`에 빠진 필드가 없는지 확인해주세요!)
- `PostUpdateView.put()`에서 `removed_subposts`필드에는 게시물 id의 배열을 받기 때문에 `removed_subposts_id`로 필드명을 수정했습니다!