### PR TITLE
JWT refresh

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -163,8 +163,8 @@ JWT_AUTH = {
     "JWT_GET_USER_SECRET_KEY": "user.utils.jwt_get_secret_key",
     "JWT_ALGORITHM": "HS256",  # 암호화 알고리즘
     "JWT_ALLOW_REFRESH": True,
-    "JWT_EXPIRATION_DELTA": datetime.timedelta(days=1),  # 유효기간 설정
-    "JWT_REFRESH_EXPIRATION_DELTA": datetime.timedelta(days=3),  # JWT 토큰 갱신 유효기간
+    "JWT_EXPIRATION_DELTA": datetime.timedelta(days=3),  # 유효기간 설정
+    "JWT_REFRESH_EXPIRATION_DELTA": datetime.timedelta(days=365),  # JWT 토큰 갱신 유효기간
 }
 
 """

--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -1231,3 +1231,19 @@ class SearchTestCase(TestCase):
         self.assertEqual(len(data["results"]), 20)
         self.assertTrue(data["results"][0]["is_friend"])
         self.assertEqual(data["results"][0]["mutual_friends"]["count"], 0)
+
+
+class TokenTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserFactory.create(
+            first_name="와플",
+            last_name="김",
+        )
+
+    def test_refresh(self):
+        user_token = jwt_token_of(self.test_user)
+        response = self.client.post(
+            "/api/v1/token/refresh/", data={"token": user_token}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/project/user/urls.py
+++ b/project/user/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import SimpleRouter
+from rest_framework_jwt.views import refresh_jwt_token
 
 from .views import (
     UserLoginView,
@@ -71,6 +72,7 @@ urlpatterns = [
     ),
     path("friend/", UserFriendDeleteView.as_view(), name="friend"),  # /api/v1/friend/
     path("search/", UserSearchListView.as_view(), name="search"),  # /api/v1/search/
+    path("token/refresh/", refresh_jwt_token),  # /api/v1/token/refresh/
 ]
 
 # urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
 - POST /api/v1/token/refresh/ 가 추가되었습니다. token : 내용 으로 보내면 동일한 형태의 200 OK 응답이 옵니다.
 - 토큰의 유효기간을 3일로, 리프레시 유효기간을 365일로 연장했습니다.
 - 테스트를 돌려서 확인했을 때는 토큰의 이름은 바뀌지 않아 약간 불안하지만, 우선 PR 올립니다.