### PR TITLE
CommentSerializer 수정

### DIFF
--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -255,6 +255,7 @@ class CommentPostSwaggerSerializer(serializers.Serializer):
 
 class CommentSerializer(serializers.ModelSerializer):
     is_liked = serializers.SerializerMethodField()
+    author_profile = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
 
@@ -264,6 +265,7 @@ class CommentSerializer(serializers.ModelSerializer):
             "id",
             "post",
             "author",
+            "author_profile",
             "content",
             "file",
             "parent",
@@ -272,6 +274,8 @@ class CommentSerializer(serializers.ModelSerializer):
             "likes",
             "is_liked",
         )
+
+        extra_kwargs = {"author": {"write_only": True}}
 
     def create(self, validated_data):
         return Comment.objects.create(
@@ -315,6 +319,9 @@ class CommentSerializer(serializers.ModelSerializer):
             return True
 
         return False
+
+    def get_author_profile(self, comment):
+        return UserSerializer(comment.author).data
 
 
 class CommentListSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
`CommentSerializer`에서 유저의 pk만 취급하는 `author`필드를 read only로 설정해두었고, UserSerializer 형태로 정보를 주는 `author_profile`필드를 추가했습니다.

따라서 다음과 같은 API들의 response에는 `author`필드 말고 `author_profile` 필드가 옵니다:
- POST /newsfeed/{post_id}/comment/
- GET, PUT /newsfeed/{post_id}/{comment_id}/