### PR TITLE
comment 생성용, 반환용 serializer 분리

### DIFF
--- a/project/newsfeed/serializers.py
+++ b/project/newsfeed/serializers.py
@@ -253,10 +253,7 @@ class CommentPostSwaggerSerializer(serializers.Serializer):
     )
 
 
-class CommentSerializer(serializers.ModelSerializer):
-    is_liked = serializers.SerializerMethodField()
-    author_profile = serializers.SerializerMethodField(read_only=True)
-
+class CommentCreateSerializer(serializers.ModelSerializer):
     class Meta:
 
         model = Comment
@@ -265,17 +262,9 @@ class CommentSerializer(serializers.ModelSerializer):
             "id",
             "post",
             "author",
-            "author_profile",
             "content",
-            "file",
             "parent",
-            "depth",
-            "created",
-            "likes",
-            "is_liked",
         )
-
-        extra_kwargs = {"author": {"write_only": True}}
 
     def create(self, validated_data):
         return Comment.objects.create(
@@ -310,6 +299,28 @@ class CommentSerializer(serializers.ModelSerializer):
 
         return data
 
+
+class CommentSerializer(serializers.ModelSerializer):
+    is_liked = serializers.SerializerMethodField()
+    author = serializers.SerializerMethodField()
+
+    class Meta:
+
+        model = Comment
+
+        fields = (
+            "id",
+            "post",
+            "author",
+            "content",
+            "file",
+            "parent",
+            "depth",
+            "created",
+            "likes",
+            "is_liked",
+        )
+
     def get_is_liked(self, comment):
         request = self.context.get("request")
         if not request:
@@ -320,7 +331,7 @@ class CommentSerializer(serializers.ModelSerializer):
 
         return False
 
-    def get_author_profile(self, comment):
+    def get_author(self, comment):
         return UserSerializer(comment.author).data
 
 

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -20,6 +20,7 @@ from .serializers import (
     PostSerializer,
     PostLikeSerializer,
     CommentListSerializer,
+    CommentCreateSerializer,
     CommentSerializer,
     CommentLikeSerializer,
     CommentPostSwaggerSerializer,
@@ -407,7 +408,9 @@ class CommentListView(ListCreateAPIView):
             )
         """
         # 친구만 댓글 달 수 있도록 하는 기능 해제
-        serializer = CommentSerializer(data=data, context={"user": user, "post": post})
+        serializer = CommentCreateSerializer(
+            data=data, context={"user": user, "post": post}
+        )
         serializer.is_valid(raise_exception=True)
         comment = serializer.save()
 
@@ -433,9 +436,7 @@ class CommentListView(ListCreateAPIView):
                     post=post,
                 )
 
-        return Response(
-            self.get_serializer(comment).data, status=status.HTTP_201_CREATED
-        )
+        return Response(CommentSerializer(comment).data, status=status.HTTP_201_CREATED)
 
 
 class CommentUpdateDeleteView(APIView):


### PR DESCRIPTION
댓글을 생성하는 serializer와 response 형식에 맞추는 serializer를 분리했습니다. 아래 API들의 `author`에는 이제 유저 정보가 담깁니다.

- POST /newsfeed/{post_id}/comment/
- GET, PUT /newsfeed/{post_id}/{comment_id}/