### PR TITLE
프로필에서 친구 관계를 반환

### DIFF
--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -313,7 +313,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
         current_user = request.user
         if user.id == current_user.id:
             return "self"
-        if user.friends.all.contains(current_user):
+        if user.friends.all().filter(id=current_user.id).exists():
             return "friend"
         if current_user.sent_friend_request.filter(receiver=user).exists():
             return "sent"

--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -259,6 +259,10 @@ class UserProfileSerializer(serializers.ModelSerializer):
 
     company = CompanySerializer(many=True, read_only=True)
     university = UniversitySerializer(many=True, read_only=True)
+    friend_info = serializers.SerializerMethodField(
+        read_only=True,
+        help_text="오류 상황시 None, 본인이면 self, 친구이면 friend, 로그인된 유저가 요청을 보냈으면 sent, 로그인된 유저가 요청을 받았으면 received, 아무것도 아니면 nothing",
+    )
 
     class Meta:
         model = User
@@ -275,6 +279,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "cover_image",
             "company",
             "university",
+            "friend_info",
         )
         read_only_fields = (
             "id",
@@ -300,6 +305,21 @@ class UserProfileSerializer(serializers.ModelSerializer):
         user.username = user.last_name + user.first_name
         user.save()
         return user
+
+    def get_friend_info(self, user):
+        request = self.context.get("request")
+        if not request:
+            return None
+        current_user = request.user
+        if user.id == current_user.id:
+            return "self"
+        if user.friends.all.contains(current_user):
+            return "friend"
+        if current_user.sent_friend_request.filter(receiver=user).exists():
+            return "sent"
+        if user.sent_friend_request.filter(receiver=current_user).exists():
+            return "received"
+        return "nothing"
 
 
 class FriendRequestCreateSerializer(serializers.ModelSerializer):

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -469,7 +469,11 @@ class UserProfileView(RetrieveUpdateAPIView):
         responses={200: UserProfileSerializer()},
     )
     def get(self, request, pk=None):
-        return super().retrieve(request, pk=pk)
+        user = get_object_or_404(self.queryset, pk=pk)
+        return Response(
+            status=status.HTTP_200_OK,
+            data=self.serializer_class(user, context={"request": request}).data,
+        )
 
     @swagger_auto_schema(
         operation_description="프로필 정보 편집하기",


### PR DESCRIPTION
- 기존의 프로필 시리얼라이저에서 friend_info 필드를 파서, 오류 상황시 None, 본인이면 self, 친구이면 friend, 로그인된 유저가 요청을 보냈으면 sent, 로그인된 유저가 요청을 받았으면 received, 아무것도 아니면 nothing을 반환하게 했습니다. 
- 위 내용을 help_text로 스웨거에 추가했습니다.
- 테스트를 작성했습니다.