### PR TITLE
함께 아는 친구 정보 불러오기

### DIFF
--- a/project/user/serializers.py
+++ b/project/user/serializers.py
@@ -331,9 +331,11 @@ class FriendRequestCreateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("자신에게 친구 요청을 보낼 수 없습니다.")
         return data
 
-    @swagger_serializer_method(serializer_or_field=UserSerializer)
+    @swagger_serializer_method(serializer_or_field=UserMutualFriendsSerializer)
     def get_sender_profile(self, friend_request):
-        return UserSerializer(friend_request.sender).data
+        return UserMutualFriendsSerializer(
+            friend_request.sender, context=self.context
+        ).data
 
 
 # 친구 요청 수락 및 삭제

--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -544,6 +544,7 @@ class UserFriendTestCase(TestCase):
         # 테스트 프렌트의 친구는 유저뿐
         self.assertEqual(len(data["results"]), 1)
         self.assertEqual(data["results"][0]["username"], self.test_user.username)
+        self.assertEqual(data["results"][0]["mutual_friends"], None)
 
         response = self.client.get(
             f"/api/v1/user/{self.test_user.id}/friend/",
@@ -554,6 +555,7 @@ class UserFriendTestCase(TestCase):
         data = response.json()
         # 페이지네이션 돼서 20개
         self.assertEqual(len(data["results"]), 20)
+        self.assertEqual(data["results"][0]["mutual_friends"]["count"], 0)
 
         response = self.client.get(
             f"/api/v1/user/{self.test_user.id}/friend/?limit=9",
@@ -1150,6 +1152,9 @@ class FriendTestCase(TestCase):
         self.assertEqual(len(data["results"]), 20)
         self.assertIn(
             data["results"][0]["sender"], [sender.id for sender in self.senders]
+        )
+        self.assertEqual(
+            data["results"][0]["sender_profile"]["mutual_friends"]["count"], 0
         )
 
         next_page = data["next"]

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -164,6 +164,11 @@ class UserFriendRequestListView(ListAPIView):
         self.queryset = request.user.received_friend_request.all()
         return super().list(request)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["request"] = self.request
+        return context
+
 
 class UserFriendRequestView(APIView):
     queryset = User.objects.all()
@@ -178,7 +183,9 @@ class UserFriendRequestView(APIView):
         receiver = get_object_or_404(self.queryset, pk=pk)
 
         data = {"sender": sender.id, "receiver": receiver.id}
-        serializer = FriendRequestCreateSerializer(data=data)
+        serializer = FriendRequestCreateSerializer(
+            data=data, context={"request": self.request}
+        )
         serializer.is_valid(raise_exception=True)
         serializer.save()
         NoticeCreate(
@@ -445,7 +452,7 @@ class UserNewsfeedView(ListAPIView):
 
 
 class UserFriendListView(ListAPIView):
-    serializer_class = UserSerializer
+    serializer_class = UserMutualFriendsSerializer
     queryset = User.objects.all()
     permission_classes = (permissions.IsAuthenticated,)
     pagination_class = FriendPagination
@@ -458,6 +465,11 @@ class UserFriendListView(ListAPIView):
         user = get_object_or_404(User, pk=user_id)
         self.queryset = user.friends.all()
         return super().list(request)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["request"] = self.request
+        return context
 
 
 class UserProfileView(RetrieveUpdateAPIView):


### PR DESCRIPTION
다음의 api에서 userserializer로 처리하던 부분을 usermutualfriendserializer로 변경하였습니다.
- GET user/{user_id}/friend/
- GET friend/request/
- POST friend/request/{pk}/
테스트를 추가했습니다.