### PR TITLE
이메일 인증을 하지 않은 유저가 로그인이 필요한 API를 이용하려고 하면 403 Forbidden을 반환

### DIFF
--- a/project/config/permissions.py
+++ b/project/config/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsValidAccount(BasePermission):
+    # is_valid가 참인 유저만 접근
+    def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+        return request.user.is_valid

--- a/project/newsfeed/views.py
+++ b/project/newsfeed/views.py
@@ -31,13 +31,14 @@ from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema, no_body
 from rest_framework.parsers import DataAndFiles, MultiPartParser, FormParser, JSONParser
 from notice.views import NoticeCancel, NoticeCreate
+from config.permissions import IsValidAccount
 
 
 class PostListView(ListCreateAPIView):
 
     serializer_class = PostSerializer
     queryset = Post.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
     parser_classes = (MultiPartParser,)
 
     @swagger_auto_schema(
@@ -148,7 +149,7 @@ class PostListView(ListCreateAPIView):
 class PostUpdateView(RetrieveUpdateDestroyAPIView):
     serializer_class = PostSerializer
     queryset = Post.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
     parser_classes = (
         MultiPartParser,
         FormParser,
@@ -380,7 +381,7 @@ class PostUpdateView(RetrieveUpdateDestroyAPIView):
 class PostLikeView(GenericAPIView):
     serializer_class = PostSerializer
     queryset = Post.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="게시물 좋아요하기",
@@ -437,7 +438,7 @@ class PostLikeView(GenericAPIView):
 class CommentListView(ListCreateAPIView):
     serializer_class = CommentListSerializer
     queryset = Post.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
     parser_classes = (parsers.MultiPartParser, parsers.FileUploadParser)
 
     # ListModelMixin의 list() 메소드 오버라이딩
@@ -543,7 +544,7 @@ class CommentListView(ListCreateAPIView):
 
 class CommentUpdateDeleteView(GenericAPIView):
     serializer_class = CommentSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
     queryset = Comment.objects.all()
     parser_classes = (parsers.MultiPartParser,)
 
@@ -670,7 +671,7 @@ class CommentUpdateDeleteView(GenericAPIView):
 class CommentLikeView(GenericAPIView):
     serializer_class = CommentSerializer
     queryset = Comment.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="comment 좋아요하기",

--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -398,6 +398,18 @@ class LogoutTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual(user_token, "JWT " + jwt_token_of(self.user))
 
+    def test_logout_invalid_user(self):
+        self.user.is_valid = False
+        self.user.save()
+        user_token = "JWT " + jwt_token_of(self.user)
+        response = self.client.get(
+            "/api/v1/account/logout/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(user_token, "JWT " + jwt_token_of(self.user))
+
 
 class AccountDeletTestCase(TestCase):
     @classmethod

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -49,6 +49,7 @@ from user.swagger import (
 from newsfeed.models import Post
 from drf_yasg.utils import swagger_auto_schema
 from .utils import account_activation_token, message
+from config.permissions import IsValidAccount
 import uuid
 
 from newsfeed.views import NoticeCreate, NoticeCancel
@@ -121,7 +122,7 @@ class UserLoginView(APIView):
 
 
 class UserLogoutView(APIView):
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     def get(self, request):
         request.user.jwt_secret = uuid.uuid4()
@@ -131,7 +132,7 @@ class UserLogoutView(APIView):
 
 
 class UserDeleteView(APIView):
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(operation_description="계정 삭제하기")
     @transaction.atomic
@@ -154,7 +155,7 @@ class UserDeleteView(APIView):
 class UserFriendRequestListView(ListAPIView):
     serializer_class = FriendRequestCreateSerializer
     queryset = FriendRequest.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="친구 요청 목록 불러오기",
@@ -172,7 +173,7 @@ class UserFriendRequestListView(ListAPIView):
 
 class UserFriendRequestView(APIView):
     queryset = User.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="해당 유저에게 친구 요청 보내기",
@@ -243,7 +244,7 @@ class UserFriendRequestView(APIView):
 
 class UserFriendDeleteView(APIView):
     serializer_class = UserSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="친구 삭제하기",
@@ -270,7 +271,7 @@ class UserFriendDeleteView(APIView):
 
 class UserSearchListView(ListAPIView):
     serializer_class = UserMutualFriendsSerializer
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
     pagination_class = UserPagination
 
     @swagger_auto_schema(
@@ -347,7 +348,7 @@ class KakaoLoginView(APIView):
 
 
 class KakaoConnectView(APIView):
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="카카오 계정 연결하기",
@@ -430,7 +431,7 @@ class KakaoConnectView(APIView):
 class UserNewsfeedView(ListAPIView):
     serializer_class = PostSerializer
     queryset = Post.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="선택된 유저가 작성한 게시글을 가져오기",
@@ -454,7 +455,7 @@ class UserNewsfeedView(ListAPIView):
 class UserFriendListView(ListAPIView):
     serializer_class = UserMutualFriendsSerializer
     queryset = User.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
     pagination_class = FriendPagination
 
     @swagger_auto_schema(
@@ -475,7 +476,7 @@ class UserFriendListView(ListAPIView):
 class UserProfileView(RetrieveUpdateAPIView):
     serializer_class = UserProfileSerializer
     queryset = User.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
     parser_classes = (parsers.MultiPartParser, parsers.FileUploadParser)
 
     @swagger_auto_schema(
@@ -531,7 +532,7 @@ class UserProfileView(RetrieveUpdateAPIView):
 class UserProfileImageView(APIView):
     serializer_class = UserProfileSerializer
     queryset = User.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="True값으로 주어진 프로필/배경 사진 삭제하기",
@@ -557,7 +558,7 @@ class UserProfileImageView(APIView):
 class CompanyCreateView(CreateAPIView):
     serializer_class = CompanySerializer
     queryset = Company.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="회사 정보 생성하기",
@@ -577,7 +578,7 @@ class CompanyCreateView(CreateAPIView):
 class CompanyView(RetrieveUpdateDestroyAPIView):
     serializer_class = CompanySerializer
     queryset = Company.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="회사 정보 가져오기",
@@ -618,7 +619,7 @@ class CompanyView(RetrieveUpdateDestroyAPIView):
 class UniversityCreateView(CreateAPIView):
     serializer_class = UniversitySerializer
     queryset = University.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="대학 정보 수정하기",
@@ -638,7 +639,7 @@ class UniversityCreateView(CreateAPIView):
 class UniversityView(RetrieveUpdateDestroyAPIView):
     serializer_class = UniversitySerializer
     queryset = University.objects.all()
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
 
     @swagger_auto_schema(
         operation_description="대학 정보 가져오기",


### PR DESCRIPTION
이메일 인증을 하지 않은 유저가 로그인이 필요한 API를 이용하려고 하면 403 Forbidden을 반환하도록 했습니다.
- config/permissions.py 에 IsValidAccount를 추가했습니다. 
- 기존의 permissions.isAuthenticated가 붙어있던 API들에 IsValidAccount 조건을 넣었습니다.
- 테스트를 단 하나... 만 추가했습니다. 원래는 모든 API에 대해 추가하는게 바람직하겠지만 괜한 코드 길어짐일까 싶고, 변경사항은 모두 동일하므로 로그아웃 API에 대해서 잘 동작하는지 확인했습니다.


앞으로 permissions.isAuthenticated를 넣을 때, 이번에 추가한 조건을 같이 넣어주시면 될 것 같습니다. 넣는 방법은 이번 PR 변경사항 참고해주시면 될 것 같습니다.