### PR TITLE
notice 읽기 전체 해제

### DIFF
--- a/project/notice/migrations/0002_notice_is_accepted.py
+++ b/project/notice/migrations/0002_notice_is_accepted.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('notice', '0001_initial'),
+        ("notice", "0001_initial"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='notice',
-            name='is_accepted',
+            model_name="notice",
+            name="is_accepted",
             field=models.BooleanField(default=False),
         ),
     ]

--- a/project/notice/migrations/0003_alter_notice_created.py
+++ b/project/notice/migrations/0003_alter_notice_created.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('notice', '0002_notice_is_accepted'),
+        ("notice", "0002_notice_is_accepted"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='notice',
-            name='created',
+            model_name="notice",
+            name="created",
             field=models.DateTimeField(auto_now_add=True),
         ),
     ]

--- a/project/notice/views.py
+++ b/project/notice/views.py
@@ -5,7 +5,7 @@ from newsfeed.serializers import PostSerializer
 from rest_framework.response import Response
 from rest_framework.generics import GenericAPIView, ListAPIView
 from django.shortcuts import get_object_or_404
-from drf_yasg.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema, no_body
 from rest_framework import status, permissions
 from newsfeed.models import Post
 from datetime import datetime
@@ -177,6 +177,11 @@ class NoticeListView(ListAPIView):
         self.queryset = request.user.notices.all()
         return super().list(request)
 
+    @swagger_auto_schema(
+        operation_description="테스트용: 유저의 모든 알림의 is_checked를 False로 전환",
+        request_body=no_body,
+        responses={200: NoticelistSerializer(many=True)},
+    )
     def put(self, request):
         notices = request.user.notices.all()
         for notice in notices:

--- a/project/notice/views.py
+++ b/project/notice/views.py
@@ -177,6 +177,14 @@ class NoticeListView(ListAPIView):
         self.queryset = request.user.notices.all()
         return super().list(request)
 
+    def put(self, request):
+        notices = request.user.notices.all()
+        for notice in notices:
+            notice.is_checked = False
+            notice.save()
+        self.queryset = request.user.notices.all()
+        return super().list(request)
+
 
 class NoticeOnOffView(GenericAPIView):
     serializer_class = PostSerializer


### PR DESCRIPTION
[PUT] api/v1/notices/
- 테스트용 알림 전체 안읽음 처리를 구현했습니다. 위 처럼 put으로 호출하면 해당 유저의 모든 알림의 is_checked 가 False로 바뀝니다. 테스트 후에 is_checked를 False가 아닌 True로 수정하면, 페이스북의 알림 전체 읽기 기능으로 응용할 수 있을 것 같습니다.

- 추가로 team9@test.com의 알림 예시들 중에 FriendAccept와 is_accepted가 True인 FriendRequest 알림도 추가해 주었습니다.

- 현재 알림이 발생되는 경우와 알림 관련 기능 다음과 같습니다.
1. 내 게시물을 남이 좋아요 눌렀을 때 (PostLike)
2. 내 게시물에 남이 댓글을 달았을 때 (PostComment)
3. 내 댓글에 남이 좋아요 눌렀을 때 (CommentLike)
4. 내 댓글에 남이 답글을 달았을 때 (CommentComment)
5. 나에게 남이 친구요청을 보냈을 때 (FriendRequest)
6. 남이 나의 친구요청을 수락할 때 (FriendAccept)
7. 남의 게시물에서 나를 태그했을 때 (PostTag)
8. 남의 댓글에서 나를 태그했을 때 (CommentTag)

9. 알림 목록 불러오기 [GET] api/v1/notices/
10. 특정 알림 읽기 [GET] api/v1/notices/<int: notice_id>/
11. 특정 알림 삭제하기 [DELETE] api/v1/notices/<int:notice_id>/
12. 특정 게시물에 대한 알림 켜기, 끄기 [PUT] api/v1/newsfeed/<int: post_id>/notice/
13. 알림을 모두 안읽음 처리 [PUT] api/v1/notices/