### PR TITLE
친구 정보 UserMutualFriendSerializer에 추가

### DIFF
--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -568,6 +568,7 @@ class UserFriendTestCase(TestCase):
         # 페이지네이션 돼서 20개
         self.assertEqual(len(data["results"]), 20)
         self.assertEqual(data["results"][0]["mutual_friends"]["count"], 0)
+        self.assertEqual(data["results"][0]["friend_info"], "friend")
 
         response = self.client.get(
             f"/api/v1/user/{self.test_user.id}/friend/?limit=9",


### PR DESCRIPTION
기존에 유저 프로필 시리얼라이저에 있던 친구 정보 필드를, 함께 아는 친구를 보여주는 시리얼라이저에도 추가했습니다.