### PR TITLE
이메일 인증이 안된 유저가 사용할 수 있는 api 생성 및 수정

### DIFF
--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -376,6 +376,56 @@ class LoginTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+class UserStatusTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(
+            email="waffle@test.com",
+            first_name="민준",
+            last_name="이",
+            birth="2002-05-14",
+            gender="Male",
+            password="password",
+        )
+
+    def test_status(self):
+        user_token = "JWT " + jwt_token_of(self.user)
+        response = self.client.get(
+            "/api/v1/account/status/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], self.user.id)
+        self.assertEqual(data["email"], self.user.email)
+        self.assertEqual(data["username"], self.user.username)
+        self.assertEqual(data["is_valid"], self.user.is_valid)
+
+    def test_status_invalid_user(self):
+        self.user.is_valid = False
+        self.user.save()
+        user_token = "JWT " + jwt_token_of(self.user)
+        response = self.client.get(
+            "/api/v1/account/status/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["id"], self.user.id)
+        self.assertEqual(data["email"], self.user.email)
+        self.assertEqual(data["username"], self.user.username)
+        self.assertEqual(data["is_valid"], self.user.is_valid)
+
+    def test_status_unauthorized(self):
+        response = self.client.get(
+            "/api/v1/account/status/",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
 class LogoutTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/project/user/tests.py
+++ b/project/user/tests.py
@@ -407,8 +407,8 @@ class LogoutTestCase(TestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=user_token,
         )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(user_token, "JWT " + jwt_token_of(self.user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotEqual(user_token, "JWT " + jwt_token_of(self.user))
 
 
 class AccountDeletTestCase(TestCase):
@@ -429,6 +429,20 @@ class AccountDeletTestCase(TestCase):
         }
 
     def test_accont_delete(self):
+        user_token = "JWT " + jwt_token_of(self.user)
+        user_id = self.user.id
+        response = self.client.delete(
+            "/api/v1/account/delete/",
+            data=self.post_data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(User.objects.filter(pk=user_id))
+
+    def test_account_delete_invalid_user(self):
+        self.user.is_valid = False
+        self.user.save()
         user_token = "JWT " + jwt_token_of(self.user)
         user_id = self.user.id
         response = self.client.delete(
@@ -511,6 +525,17 @@ class UserNewsFeedTestCase(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_user_post_invalid_user(self):
+        self.test_user.is_valid = False
+        self.test_user.save()
+        user_token = "JWT " + jwt_token_of(self.test_user)
+        response = self.client.get(
+            f"/api/v1/user/{self.test_user.id}/newsfeed/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class UserFriendTestCase(TestCase):

--- a/project/user/urls.py
+++ b/project/user/urls.py
@@ -5,6 +5,7 @@ from rest_framework_jwt.views import refresh_jwt_token
 from .views import (
     UserLoginView,
     UserSignUpView,
+    UserStatusView,
     UserLogoutView,
     KakaoLoginView,
     KakaoConnectView,
@@ -38,6 +39,9 @@ urlpatterns = [
     path(
         "account/login/", UserLoginView.as_view(), name="account_login"
     ),  # /api/v1/account/login/
+    path(
+        "account/status/", UserStatusView.as_view(), name="account_status"
+    ),  # /api/v1/account/status/
     path(
         "account/logout/", UserLogoutView.as_view(), name="account_logout"
     ),  # /api/v1/account/logout/

--- a/project/user/views.py
+++ b/project/user/views.py
@@ -121,8 +121,17 @@ class UserLoginView(APIView):
         )
 
 
+class UserStatusView(APIView):
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request):
+        return Response(
+            data=UserSerializer(request.user).data, status=status.HTTP_200_OK
+        )
+
+
 class UserLogoutView(APIView):
-    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
+    permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request):
         request.user.jwt_secret = uuid.uuid4()
@@ -132,7 +141,7 @@ class UserLogoutView(APIView):
 
 
 class UserDeleteView(APIView):
-    permission_classes = (permissions.IsAuthenticated & IsValidAccount,)
+    permission_classes = (permissions.IsAuthenticated,)
 
     @swagger_auto_schema(operation_description="계정 삭제하기")
     @transaction.atomic


### PR DESCRIPTION
- 로그아웃과 탈퇴는 이메일 인증이 되지 않아도 사용할 수 있도록 변경했습니다.
- 유저의 현재 상태(UserSerializer)를 반환하는 api(GET /account/status/)를 만들었고, 이메일 인증이 되지 않아도 사용할 수 있도록 했습니다.
- 테스트를 추가했습니다.